### PR TITLE
Initial commit of PackML state machine

### DIFF
--- a/packml_sm/CMakeLists.txt
+++ b/packml_sm/CMakeLists.txt
@@ -12,10 +12,16 @@ endif()
 
 set(packml_sm_SRCS
   src/state_machine.cpp
+  src/state.cpp
+  src/transitions.cpp
 )
 
 set(packml_sm_HDRS
   include/packml_sm/state_machine.h
+  include/packml_sm/state.h
+  include/packml_sm/transitions.h
+  include/packml_sm/events.h
+  include/packml_sm/common.h
 )
 
 set(packml_sm_INCLUDE_DIRECTORIES

--- a/packml_sm/CMakeLists.txt
+++ b/packml_sm/CMakeLists.txt
@@ -1,0 +1,108 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(packml_sm)
+find_package(catkin REQUIRED rqt_gui rqt_gui_cpp)
+
+if("${qt_gui_cpp_USE_QT_MAJOR_VERSION} " STREQUAL "5 ")
+  find_package(Qt5Widgets REQUIRED)
+else()
+  find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
+  include(${QT_USE_FILE})
+endif()
+
+
+set(packml_sm_SRCS
+  src/state_machine.cpp
+)
+
+set(packml_sm_HDRS
+  include/packml_sm/state_machine.h
+)
+
+set(packml_sm_INCLUDE_DIRECTORIES
+  include
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+
+catkin_package(
+  INCLUDE_DIRS ${packml_sm_INCLUDE_DIRECTORIES}
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS rqt_gui rqt_gui_cpp
+  DEPENDS
+)
+
+
+if("${qt_gui_cpp_USE_QT_MAJOR_VERSION} " STREQUAL "5 ")
+  qt5_wrap_cpp(packml_sm_MOCS ${packml_sm_HDRS})
+  #qt5_wrap_ui(packml_sm__UIS_H ${packml_sm_UIS})
+else()
+  qt4_wrap_cpp(packml_sm_MOCS ${packml_sm_HDRS})
+  #qt4_wrap_ui(packml_sm__UIS_H ${packml_sm_UIS})
+endif()
+
+include_directories(${packml_sm_INCLUDE_DIRECTORIES} ${catkin_INCLUDE_DIRS})
+add_library(${PROJECT_NAME} ${packml_sm_SRCS} ${packml_sm_MOCS})
+#add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+if("${qt_gui_cpp_USE_QT_MAJOR_VERSION} " STREQUAL "5 ")
+  target_link_libraries(${PROJECT_NAME} Qt5::Widgets)
+else()
+  target_link_libraries(${PROJECT_NAME} ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY})
+endif()
+
+target_compile_options(${PROJECT_NAME} PUBLIC -std=c++11)
+
+##find_package(class_loader)
+##class_loader_hide_library_symbols(${PROJECT_NAME})
+
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS packml_sm packml_sm_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest)
+  set(UTEST_SRC_FILES test/utest.cpp
+      test/state_machine.cpp)
+
+  catkin_add_gtest(${PROJECT_NAME}_utest ${UTEST_SRC_FILES})
+  target_compile_options(${PROJECT_NAME}_utest PUBLIC -std=c++11)
+  target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
+endif()
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/packml_sm/include/packml_sm/common.h
+++ b/packml_sm/include/packml_sm/common.h
@@ -1,0 +1,89 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef COMMON_H
+#define COMMON_H
+
+namespace packml_sm
+{
+
+//This magic function allows iostream (i.e. ROS_##_STREAM) macros to print out
+//enumerations
+//see: http://stackoverflow.com/questions/11421432/how-can-i-output-the-value-of-an-enum-class-in-c11
+template<typename T>
+std::ostream& operator<<(typename std::enable_if<std::is_enum<T>::value, std::ostream>::type& stream, const T& e)
+{
+  return stream << static_cast<typename std::underlying_type<T>::type>(e);
+}
+
+enum class StatesEnum {
+  UNDEFINED = 0,
+  OFF = 1,
+  STOPPED = 2,
+  STARTING = 3,
+  IDLE = 4,
+  SUSPENDED = 5,
+  EXECUTE = 6,
+  STOPPING = 7,
+  ABORTING = 8,
+  ABORTED = 9,
+  HOLDING = 10,
+  HELD = 11,
+
+  RESETTING = 100,
+  SUSPENDING = 101,
+  UNSUSPENDING = 102,
+  CLEARING = 103,
+  UNHOLDING = 104,
+  COMPLETING = 105,
+  COMPLETE = 106,
+
+  // Super states that encapsulate multiple substates with a common transition
+  // Not explicitly used in the standard but helpful for consutrcting the state
+  // machine.
+  ABORTABLE = 200,
+  STOPPABLE = 201
+};
+
+enum class ModeEnum {
+  UNDEFINED = 0,
+  AUTOMATIC = 1,
+  SEMI_AUTOMATIC = 2,
+  MANUAL = 3,
+  IDLE = 4,
+  SETUP = 11
+};
+
+enum class CmdEnum {
+  UNDEFINED = 0,
+  CLEAR = 1,
+  START = 2,
+  STOP = 3,
+  HOLD = 4,
+  ABORT = 5,
+  RESET = 6,
+  ESTOP = 7,
+
+  SUSPEND = 100,
+  UNSUSPEND = 101,
+  UNHOLD = 102
+};
+
+}
+
+#endif // COMMON_H

--- a/packml_sm/include/packml_sm/events.h
+++ b/packml_sm/include/packml_sm/events.h
@@ -1,0 +1,96 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EVENTS_H
+#define EVENTS_H
+
+#endif // EVENTS_H
+
+
+#include "QEvent"
+#include "QAbstractTransition"
+
+#include "packml_sm/common.h"
+#include "packml_sm/state.h"
+
+namespace packml_sm
+{
+
+
+static int PACKML_CMD_EVENT_TYPE = QEvent::User+1;
+static int PACKML_STATE_COMPLETE_EVENT_TYPE = QEvent::User+2;
+
+struct CmdEvent : public QEvent
+{
+  static CmdEvent* clear()
+  {
+    return new CmdEvent(CmdEnum::CLEAR);
+  }
+  static CmdEvent* start()
+  {
+    return new CmdEvent(CmdEnum::START);
+  }
+  static CmdEvent* stop()
+  {
+    return new CmdEvent(CmdEnum::STOP);
+  }
+  static CmdEvent* hold()
+  {
+    return new CmdEvent(CmdEnum::HOLD);
+  }
+  static CmdEvent* abort()
+  {
+    return new CmdEvent(CmdEnum::ABORT);
+  }
+  static CmdEvent* reset()
+  {
+    return new CmdEvent(CmdEnum::RESET);
+  }
+  static CmdEvent* estop()
+  {
+    return new CmdEvent(CmdEnum::ESTOP);
+  }
+  static CmdEvent* suspend()
+  {
+    return new CmdEvent(CmdEnum::SUSPEND);
+  }
+  static CmdEvent* unsuspend()
+  {
+    return new CmdEvent(CmdEnum::UNSUSPEND);
+  }
+  static CmdEvent* unhold()
+  {
+    return new CmdEvent(CmdEnum::UNHOLD);
+  }
+
+  CmdEvent(const CmdEnum &cmd_value)
+    : QEvent(QEvent::Type(PACKML_CMD_EVENT_TYPE)),
+      cmd(cmd_value) {}
+
+  CmdEnum cmd;
+};
+
+
+struct StateCompleteEvent : public QEvent
+{
+  StateCompleteEvent()
+    : QEvent(QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE)) {}
+};
+
+
+} //packml_sm

--- a/packml_sm/include/packml_sm/events.h
+++ b/packml_sm/include/packml_sm/events.h
@@ -34,6 +34,7 @@ namespace packml_sm
 
 static int PACKML_CMD_EVENT_TYPE = QEvent::User+1;
 static int PACKML_STATE_COMPLETE_EVENT_TYPE = QEvent::User+2;
+static int PACKML_ERROR_EVENT_TYPE = QEvent::User+3;
 
 struct CmdEvent : public QEvent
 {
@@ -90,6 +91,28 @@ struct StateCompleteEvent : public QEvent
 {
   StateCompleteEvent()
     : QEvent(QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE)) {}
+};
+
+
+struct ErrorEvent : public QEvent
+{
+
+  ErrorEvent(const int &code_value)
+    : QEvent(QEvent::Type(PACKML_ERROR_EVENT_TYPE)),
+      code(code_value),
+      name(),
+      description() {}
+
+  ErrorEvent(const int &code_value, const QString &name_value,
+             const QString &description_value)
+    : QEvent(QEvent::Type(PACKML_ERROR_EVENT_TYPE)),
+      code(code_value),
+      name(name_value),
+      description(description_value) {}
+
+  int code;
+  QString name;
+  QString description;
 };
 
 

--- a/packml_sm/include/packml_sm/state.h
+++ b/packml_sm/include/packml_sm/state.h
@@ -153,7 +153,7 @@ public:
   {
     return new ActingState(StatesEnum::EXECUTE, "Execute", stoppable, delay_ms_value);
   }
-  static ActingState* Execute(std::function<void()> function_value)
+  static ActingState* Execute(std::function<int()> function_value)
   {
     return new ActingState(StatesEnum::EXECUTE, "Execute", function_value);
   }
@@ -184,12 +184,12 @@ public:
     delay_ms(delay_ms_value)
   {}
 
-  ActingState(StatesEnum state_value, const char* name_value, std::function<void()> function_value) :
+  ActingState(StatesEnum state_value, const char* name_value, std::function<int()> function_value) :
     PackmlState(state_value, QString(name_value)),
     function_(function_value)
   {}
 
-  bool setOperationMethod(std::function<void()> function_value)
+  bool setOperationMethod(std::function<int()> function_value)
   {
     function_ = function_value;
     return true;
@@ -201,7 +201,7 @@ protected:
 
 private:
   int delay_ms;
-  std::function<void()> function_;
+  std::function<int()> function_;
 };
 
 struct FunctionalState : public PackmlState

--- a/packml_sm/include/packml_sm/state.h
+++ b/packml_sm/include/packml_sm/state.h
@@ -151,7 +151,11 @@ public:
   }
   static ActingState* Execute(QState* stoppable, int delay_ms_value = 200)
   {
-    return new ActingState(StatesEnum::EXECUTE, "Exectue", stoppable, delay_ms_value);
+    return new ActingState(StatesEnum::EXECUTE, "Execute", stoppable, delay_ms_value);
+  }
+  static ActingState* Execute(std::function<void()> function_value)
+  {
+    return new ActingState(StatesEnum::EXECUTE, "Execute", function_value);
   }
   static ActingState* Completing(QState* stoppable, int delay_ms_value = 200)
   {
@@ -179,24 +183,8 @@ public:
     PackmlState(state_value, name_value, super_state),
     delay_ms(delay_ms_value)
   {}
-protected:
 
-  virtual void operation();
-
-private:
-  int delay_ms;
-};
-
-struct FunctionalState : public PackmlState
-{
-public:
-
-  static FunctionalState* Execute(std::function<void()> function_value)
-  {
-    return new FunctionalState(StatesEnum::EXECUTE, "Exectue", function_value);
-  }
-
-  FunctionalState(StatesEnum state_value, const char* name_value, std::function<void()> function_value) :
+  ActingState(StatesEnum state_value, const char* name_value, std::function<void()> function_value) :
     PackmlState(state_value, QString(name_value)),
     function_(function_value)
   {}
@@ -212,8 +200,22 @@ protected:
   virtual void operation();
 
 private:
-
+  int delay_ms;
   std::function<void()> function_;
+};
+
+struct FunctionalState : public PackmlState
+{
+public:
+
+
+
+protected:
+
+  virtual void operation();
+
+private:
+
 
 
 };

--- a/packml_sm/include/packml_sm/state.h
+++ b/packml_sm/include/packml_sm/state.h
@@ -19,6 +19,8 @@
 #ifndef PACKML_STATE_H
 #define PACKML_STATE_H
 
+#include <functional>
+
 #include <QtGui>
 #include "QState"
 #include "QEvent"
@@ -183,6 +185,31 @@ protected:
 
 private:
   int delay_ms;
+};
+
+struct FunctionalState : public PackmlState
+{
+public:
+
+  static FunctionalState* Execute(std::function<void()> function_value)
+  {
+    return new FunctionalState(StatesEnum::EXECUTE, "Exectue", function_value);
+  }
+
+  FunctionalState(StatesEnum state_value, const char* name_value, std::function<void()> function_value) :
+    PackmlState(state_value, QString(name_value)),
+    function_(function_value)
+  {}
+
+protected:
+
+  virtual void operation();
+
+private:
+
+  std::function<void()> function_;
+
+
 };
 
 

--- a/packml_sm/include/packml_sm/state.h
+++ b/packml_sm/include/packml_sm/state.h
@@ -1,0 +1,191 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PACKML_STATE_H
+#define PACKML_STATE_H
+
+#include <QtGui>
+#include "QState"
+#include "QEvent"
+#include "QAbstractTransition"
+
+#include "ros/console.h"
+#include "packml_sm/common.h"
+
+namespace packml_sm
+{
+
+struct PackmlState : public QState
+{
+  Q_OBJECT
+
+public:
+  PackmlState(StatesEnum state_value, QString name_value) :
+    state_(state_value),
+    name_(name_value),
+    cummulative_time_(0) {}
+
+  PackmlState(StatesEnum state_value, QString name_value, QState* super_state) :
+    QState(super_state),
+    state_(state_value),
+    name_(name_value),
+    cummulative_time_(0) {}
+
+  StatesEnum state() const {return state_;}
+  const QString name() const {return name_;}
+
+signals:
+  void stateEntered(int value, QString name);
+
+protected:
+  StatesEnum state_;
+  QString name_;
+
+  ros::Time enter_time_;
+  ros::Time exit_time_;
+  ros::Duration cummulative_time_;
+
+  virtual void onEntry(QEvent *e);
+  virtual void operation() {}
+  virtual void onExit(QEvent *e);
+};
+
+
+
+struct WaitState : public PackmlState
+{
+public:
+
+  static WaitState* Abortable()
+  {
+    return new WaitState(StatesEnum::ABORTABLE, CmdEnum::ABORT, "Abortable");
+  }
+  static WaitState* Stoppable(QState* abortable)
+  {
+    return new WaitState(StatesEnum::STOPPABLE, CmdEnum::ABORT, "Stoppable", abortable);
+  }
+  static WaitState* Idle(QState* stoppable)
+  {
+    return new WaitState(StatesEnum::IDLE, CmdEnum::START, "Idle", stoppable);
+  }
+  static WaitState* Held(QState* stoppable)
+  {
+    return new WaitState(StatesEnum::HELD, CmdEnum::UNHOLD, "Held", stoppable);
+  }
+  static WaitState* Complete(QState* stoppable)
+  {
+    return new WaitState(StatesEnum::COMPLETE, CmdEnum::RESET, "Complete", stoppable);
+  }
+  static WaitState* Suspended(QState* stoppable)
+  {
+    return new WaitState(StatesEnum::SUSPENDED, CmdEnum::UNSUSPEND, "Suspended", stoppable);
+  }
+  static WaitState* Stopped(QState* abortable)
+  {
+    return new WaitState(StatesEnum::STOPPED, CmdEnum::RESET, "Stopped", abortable);
+  }
+  static WaitState* Aborted()
+  {
+    return new WaitState(StatesEnum::ABORTED, CmdEnum::CLEAR, "Aborted");
+  }
+
+  WaitState(StatesEnum state_value, CmdEnum exit_cmd_value, QString name_value) :
+    PackmlState(state_value, name_value),
+    exit_cmd(exit_cmd_value)
+  {}
+
+  WaitState(StatesEnum state_value, CmdEnum exit_cmd_value, QString name_value, QState* super_state) :
+    PackmlState(state_value, name_value, super_state),
+    exit_cmd(exit_cmd_value)
+  {}
+
+private:
+  CmdEnum exit_cmd;
+};
+
+
+struct ActingState : public PackmlState
+{
+public:
+
+  static ActingState* Resetting(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::RESETTING, "Resetting", stoppable, delay_ms_value);
+  }
+  static ActingState* Starting(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::STARTING, "Starting", stoppable, delay_ms_value);
+  }
+  static ActingState* Unholding(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::UNHOLDING, "Un-Holding", stoppable, delay_ms_value);
+  }
+  static ActingState* Unsuspending(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::UNSUSPENDING, "Un-Suspending", stoppable, delay_ms_value);
+  }
+  static ActingState* Holding(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::HOLDING, "Holding", stoppable, delay_ms_value);
+  }
+  static ActingState* Suspending(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::SUSPENDING, "Suspending", stoppable, delay_ms_value);
+  }
+  static ActingState* Execute(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::EXECUTE, "Exectue", stoppable, delay_ms_value);
+  }
+  static ActingState* Completing(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::COMPLETING, "Completing", stoppable, delay_ms_value);
+  }
+  static ActingState* Aborting(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::ABORTING, "Aborting", delay_ms_value);
+  }
+  static ActingState* Clearing(QState* abortable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::CLEARING, "Clearing", abortable, delay_ms_value);
+  }
+  static ActingState* Stopping(QState* abortable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::STOPPING, "Aborting", abortable, delay_ms_value);
+  }
+
+  ActingState(StatesEnum state_value, const char* name_value, int delay_ms_value = 200) :
+    PackmlState(state_value, QString(name_value)),
+    delay_ms(delay_ms_value)
+  {}
+
+  ActingState(StatesEnum state_value, const QString & name_value, QState* super_state, int delay_ms_value = 200) :
+    PackmlState(state_value, name_value, super_state),
+    delay_ms(delay_ms_value)
+  {}
+protected:
+
+  virtual void operation();
+
+private:
+  int delay_ms;
+};
+
+
+}
+
+#endif // PACKML_STATE_H

--- a/packml_sm/include/packml_sm/state.h
+++ b/packml_sm/include/packml_sm/state.h
@@ -153,9 +153,9 @@ public:
   {
     return new ActingState(StatesEnum::EXECUTE, "Execute", stoppable, delay_ms_value);
   }
-  static ActingState* Execute(std::function<int()> function_value)
+  static ActingState* Execute(QState* stoppable, std::function<int()> function_value)
   {
-    return new ActingState(StatesEnum::EXECUTE, "Execute", function_value);
+    return new ActingState(StatesEnum::EXECUTE, "Execute", stoppable, function_value);
   }
   static ActingState* Completing(QState* stoppable, int delay_ms_value = 200)
   {
@@ -184,8 +184,8 @@ public:
     delay_ms(delay_ms_value)
   {}
 
-  ActingState(StatesEnum state_value, const char* name_value, std::function<int()> function_value) :
-    PackmlState(state_value, QString(name_value)),
+  ActingState(StatesEnum state_value, const char* name_value, QState* super_state, std::function<int()> function_value) :
+    PackmlState(state_value, QString(name_value), super_state),
     function_(function_value)
   {}
 
@@ -204,21 +204,7 @@ private:
   std::function<int()> function_;
 };
 
-struct FunctionalState : public PackmlState
-{
-public:
-
-
-
-protected:
-
-  virtual void operation();
-
-private:
-
-
-
-};
+typedef ActingState DualState;
 
 
 }

--- a/packml_sm/include/packml_sm/state.h
+++ b/packml_sm/include/packml_sm/state.h
@@ -201,6 +201,12 @@ public:
     function_(function_value)
   {}
 
+  bool setOperationMethod(std::function<void()> function_value)
+  {
+    function_ = function_value;
+    return true;
+  }
+
 protected:
 
   virtual void operation();

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -42,8 +42,8 @@ class StateMachineInterface
 {
 public:
 
-  virtual bool init(std::function<void()> execute_method)=0;
-  virtual bool setExecute(std::function<void()> execute_method)=0;
+  virtual bool init(std::function<int()> execute_method)=0;
+  virtual bool setExecute(std::function<int()> execute_method)=0;
   virtual bool isActive()=0;
   virtual int getCurrentState()=0;
 
@@ -56,8 +56,8 @@ class StateMachine : public QStateMachine, StateMachineInterface
 
 public:
   StateMachine();
-  bool init(std::function<void()> execute_method);
-  bool setExecute(std::function<void()> execute_method);
+  bool init(std::function<int()> execute_method);
+  bool setExecute(std::function<int()> execute_method);
 
   bool isActive()
   {

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -77,7 +77,7 @@ protected:
   int state_value_;
   QString state_name_;
 
-  FunctionalState* execute_ ;
+  ActingState* execute_ ;
 
 protected slots:
   void setState(int value, QString name);

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -33,11 +33,6 @@ namespace packml_sm
 {
 
 
-enum class StatesEnum;  //foward declaration of enum
-class StateMachine;
-
-
-
 class StateMachine : public QStateMachine
 {
   Q_OBJECT

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -42,7 +42,7 @@ class StateMachineInterface
 {
 public:
 
-  virtual bool init(std::function<int()> execute_method)=0;
+  virtual bool activate()=0;
   virtual bool setExecute(std::function<int()> execute_method)=0;
   virtual bool isActive()=0;
   virtual int getCurrentState()=0;
@@ -55,8 +55,12 @@ class StateMachine : public QStateMachine, StateMachineInterface
   Q_OBJECT
 
 public:
-  StateMachine();
-  bool init(std::function<int()> execute_method);
+
+  static std::unique_ptr<StateMachine> singleCyleSM();
+  static std::unique_ptr<StateMachine> continuousCycleSM();
+
+  bool activate();
+  bool deactivate();
   bool setExecute(std::function<int()> execute_method);
 
   bool isActive()
@@ -69,18 +73,63 @@ public:
     return state_value_;
   }
 
-  virtual ~StateMachine() {}
+  virtual ~StateMachine();
 
 
 protected:
+  StateMachine();
 
   int state_value_;
   QString state_name_;
 
-  ActingState* execute_ ;
+  WaitState* abortable_;
+  WaitState* stoppable_;
+  WaitState* held_;
+  WaitState* idle_;
+  WaitState* suspended_;
+  WaitState* stopped_;
+  WaitState* complete_;
+  WaitState* aborted_;
+
+  ActingState* unholding_;
+  ActingState* holding_;
+  ActingState* starting_;
+  ActingState* completing_;
+  ActingState* resetting_;
+  ActingState* unsuspending_;
+  ActingState* suspending_;
+  ActingState* stopping_;
+  ActingState* clearing_;
+  ActingState* aborting_;
+
+  DualState* execute_;
+
+
 
 protected slots:
   void setState(int value, QString name);
+
+};
+
+class ContinuousCycle : public StateMachine
+{
+  Q_OBJECT
+
+public:
+
+  ContinuousCycle();
+  virtual ~ContinuousCycle() {}
+
+};
+
+class SingleCycle : public StateMachine
+{
+  Q_OBJECT
+
+public:
+
+  SingleCycle();
+  virtual ~SingleCycle() {}
 
 };
 

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -43,6 +43,7 @@ class StateMachineInterface
 public:
 
   virtual bool init(std::function<void()> execute_method)=0;
+  virtual bool setExecute(std::function<void()> execute_method)=0;
   virtual bool isActive()=0;
   virtual int getCurrentState()=0;
 
@@ -55,8 +56,8 @@ class StateMachine : public QStateMachine, StateMachineInterface
 
 public:
   StateMachine();
-  bool init(PackmlState* execute_state);
   bool init(std::function<void()> execute_method);
+  bool setExecute(std::function<void()> execute_method);
 
   bool isActive()
   {
@@ -75,6 +76,8 @@ protected:
 
   int state_value_;
   QString state_name_;
+
+  FunctionalState* execute_ ;
 
 protected slots:
   void setState(int value, QString name);

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -32,15 +32,40 @@
 namespace packml_sm
 {
 
+/**
+ * @brief The StateMachineInterface class defines a implementation independent interface
+ * to a PackML state machine.
+ */
+class StateMachineInterface
+{
+public:
 
-class StateMachine : public QStateMachine
+  virtual bool init()=0;
+  virtual bool isActive()=0;
+  virtual int getCurrentState()=0;
+
+};
+
+
+class StateMachine : public QStateMachine, StateMachineInterface
 {
   Q_OBJECT
 
 public:
   StateMachine();
   StateMachine(PackmlState* execute_state);
-  void init(PackmlState* execute_state);
+  bool init(PackmlState* execute_state);
+
+  bool init()
+  {
+    return init(ActingState::Execute(NULL));
+  }
+
+  bool isActive()
+  {
+    return isRunning();
+  }
+
   int getCurrentState()
   {
     return state_value_;
@@ -50,7 +75,7 @@ public:
 
 
 protected:
-  QThread worker_;
+
   int state_value_;
   QString state_name_;
 

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -20,6 +20,8 @@
 #ifndef STATE_MACHINE_H
 #define STATE_MACHINE_H
 
+#include <functional>
+
 #include <QtGui>
 #include "QEvent"
 #include "QAbstractTransition"
@@ -40,7 +42,7 @@ class StateMachineInterface
 {
 public:
 
-  virtual bool init()=0;
+  virtual bool init(std::function<void()> execute_method)=0;
   virtual bool isActive()=0;
   virtual int getCurrentState()=0;
 
@@ -53,13 +55,8 @@ class StateMachine : public QStateMachine, StateMachineInterface
 
 public:
   StateMachine();
-  StateMachine(PackmlState* execute_state);
   bool init(PackmlState* execute_state);
-
-  bool init()
-  {
-    return init(ActingState::Execute(NULL));
-  }
+  bool init(std::function<void()> execute_method);
 
   bool isActive()
   {

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -22,15 +22,412 @@
 #include "QEvent"
 #include "QAbstractTransition"
 
+#include "packml_msgs/State.h"
+#include "packml_msgs/StateCommand.h"
+#include "ros/console.h"
+
 namespace packml_sm
 {
 
+enum class StatesEnum;  //foward declaration of enum
+struct BaseState : public QState
+{
+public:
+  BaseState(StatesEnum state_value, QString name_value) :
+    state_(state_value),
+    name_(name_value) {}
+
+  BaseState(StatesEnum state_value, QString name_value, QState* super_state) :
+    QState(super_state),
+    state_(state_value),
+    name_(name_value) {}
+
+  StatesEnum state() const {return state_;}
+  const QString name() const {return name_;}
+
+protected:
+  StatesEnum state_;
+  QString name_;
+};
+
+
+//This magic function allows iostream (i.e. ROS_##_STREAM) macros to print out
+//enumerations
+//see: http://stackoverflow.com/questions/11421432/how-can-i-output-the-value-of-an-enum-class-in-c11
+template<typename T>
+std::ostream& operator<<(typename std::enable_if<std::is_enum<T>::value, std::ostream>::type& stream, const T& e)
+{
+  return stream << static_cast<typename std::underlying_type<T>::type>(e);
+}
+
+static int PACKML_CMD_EVENT_TYPE = QEvent::User+1;
+static int PACKML_STATE_COMPLETE_EVENT_TYPE = QEvent::User+2;
+
+enum class StatesEnum {
+  UNDEFINED = 0,
+  OFF = 1,
+  STOPPED = 2,
+  STARTING = 3,
+  IDLE = 4,
+  SUSPENDED = 5,
+  EXECUTE = 6,
+  STOPPING = 7,
+  ABORTING = 8,
+  ABORTED = 9,
+  HOLDING = 10,
+  HELD = 11,
+
+  RESETTING = 100,
+  SUSPENDING = 101,
+  UNSUSPENDING = 102,
+  CLEARING = 103,
+  UNHOLDING = 104,
+  COMPLETING = 105,
+  COMPLETE = 106,
+
+  // Super states that encapsulate multiple substates with a common transition
+  // Not explicitly used in the standard but helpful for consutrcting the state
+  // machine.
+  ABORTABLE = 200,
+  STOPPABLE = 201
+};
+
+enum class ModeEnum {
+  UNDEFINED = 0,
+  AUTOMATIC = 1,
+  SEMI_AUTOMATIC = 2,
+  MANUAL = 3,
+  IDLE = 4,
+  SETUP = 11
+};
+
+enum class CmdEnum {
+  UNDEFINED = 0,
+  CLEAR = 1,
+  START = 2,
+  STOP = 3,
+  HOLD = 4,
+  ABORT = 5,
+  RESET = 6,
+  ESTOP = 7,
+
+  SUSPEND = 100,
+  UNSUSPEND = 101,
+  UNHOLD = 102
+};
+
+
+struct CmdEvent : public QEvent
+{
+  static CmdEvent* clear()
+  {
+    return new CmdEvent(CmdEnum::CLEAR);
+  }
+  static CmdEvent* start()
+  {
+    return new CmdEvent(CmdEnum::START);
+  }
+  static CmdEvent* stop()
+  {
+    return new CmdEvent(CmdEnum::STOP);
+  }
+  static CmdEvent* hold()
+  {
+    return new CmdEvent(CmdEnum::HOLD);
+  }
+  static CmdEvent* abort()
+  {
+    return new CmdEvent(CmdEnum::ABORT);
+  }
+  static CmdEvent* reset()
+  {
+    return new CmdEvent(CmdEnum::RESET);
+  }
+  static CmdEvent* estop()
+  {
+    return new CmdEvent(CmdEnum::ESTOP);
+  }
+  static CmdEvent* suspend()
+  {
+    return new CmdEvent(CmdEnum::SUSPEND);
+  }
+  static CmdEvent* unsuspend()
+  {
+    return new CmdEvent(CmdEnum::UNSUSPEND);
+  }
+  static CmdEvent* unhold()
+  {
+    return new CmdEvent(CmdEnum::UNHOLD);
+  }
+
+  CmdEvent(const CmdEnum &cmd_value)
+    : QEvent(QEvent::Type(PACKML_CMD_EVENT_TYPE)),
+      cmd(cmd_value) {}
+
+  CmdEnum cmd;
+};
+
+class CmdTransition : public QAbstractTransition
+{
+public:
+
+
+  static CmdTransition* clear(BaseState & from, BaseState & to)
+  {
+    return new CmdTransition(CmdEnum::CLEAR, "clear", from, to);
+  }
+  static CmdTransition* start(BaseState & from, BaseState & to)
+  {
+    return new CmdTransition(CmdEnum::START, "start", from, to);
+  }
+  static CmdTransition* stop(BaseState & from, BaseState & to)
+  {
+    return new CmdTransition(CmdEnum::STOP, "stop", from, to);
+  }
+  static CmdTransition* hold(BaseState & from, BaseState & to)
+  {
+    return new CmdTransition(CmdEnum::HOLD, "hold", from, to);
+  }
+  static CmdTransition* abort(BaseState & from, BaseState & to)
+  {
+    return new CmdTransition(CmdEnum::ABORT, "abort", from, to);
+  }
+  static CmdTransition* reset(BaseState & from, BaseState & to)
+  {
+    return new CmdTransition(CmdEnum::RESET, "reset", from, to);
+  }
+  static CmdTransition* estop(BaseState & from, BaseState & to)
+  {
+    return new CmdTransition(CmdEnum::ESTOP, "estop", from, to);
+  }
+  static CmdTransition* suspend(BaseState & from, BaseState & to)
+  {
+    return new CmdTransition(CmdEnum::SUSPEND, "abort", from, to);
+  }
+  static CmdTransition* unsuspend(BaseState & from, BaseState & to)
+  {
+    return new CmdTransition(CmdEnum::UNSUSPEND, "unsuspend", from, to);
+  }
+  static CmdTransition* unhold(BaseState & from, BaseState & to)
+  {
+    return new CmdTransition(CmdEnum::UNHOLD, "unhold", from, to);
+  }
+
+  CmdTransition(const CmdEnum &cmd_value, const QString &name_value) :
+    cmd(cmd_value),
+    name(name_value) {}
+
+
+  CmdTransition(const CmdEnum &cmd_value, const QString &name_value,
+                BaseState & from, BaseState & to) :
+    cmd(cmd_value),
+    name(name_value)
+  {
+    this->setTargetState(&to);
+    from.addTransition(this);
+    ROS_INFO_STREAM("Creating " << this->name.toStdString() << " transition from " <<
+                    from.name().toStdString() << " to " << to.name().toStdString());
+  }
+
+protected:
+
+
+  virtual bool eventTest(QEvent *e)
+  {
+    ROS_INFO_STREAM("Testing event type: " << e->type());
+    if (e->type() != QEvent::Type(PACKML_CMD_EVENT_TYPE))
+      return false;
+    CmdEvent *se = static_cast<CmdEvent*>(e);
+    ROS_INFO_STREAM("Type cmd: " << cmd << ", event cmd: " << se->cmd);
+    return (cmd == se->cmd);
+  }
+
+  virtual void onTransition(QEvent *e) {}
+
+  CmdEnum cmd;
+  QString name;
+};
+
+
+struct StateCompleteEvent : public QEvent
+{
+  StateCompleteEvent()
+    : QEvent(QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE)) {}
+};
+
+
+class StateCompleteTransition : public QAbstractTransition
+{
+public:
+  StateCompleteTransition() {}
+
+  StateCompleteTransition(BaseState & from, BaseState & to)
+  {
+    this->setTargetState(&to);
+    from.addTransition(this);
+    ROS_INFO_STREAM("Creating state complete transition from " <<
+                    from.name().toStdString() << " to " << to.name().toStdString());
+  }
+
+  ~StateCompleteTransition() {}
+
+protected:
+  virtual bool eventTest(QEvent *e)
+  {
+    if (e->type() != QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE))
+      return false;
+    return (true);
+  }
+
+  virtual void onTransition(QEvent *e) {}
+
+private:
+};
+
+struct WaitState : public BaseState
+{
+public:
+
+  static WaitState* Abortable()
+  {
+    return new WaitState(StatesEnum::ABORTABLE, CmdEnum::ABORT, "Abortable");
+  }
+  static WaitState* Stoppable(QState* abortable)
+  {
+    return new WaitState(StatesEnum::STOPPABLE, CmdEnum::ABORT, "Stoppable", abortable);
+  }
+  static WaitState* Idle(QState* stoppable)
+  {
+    return new WaitState(StatesEnum::IDLE, CmdEnum::START, "Idle", stoppable);
+  }
+  static WaitState* Held(QState* stoppable)
+  {
+    return new WaitState(StatesEnum::HELD, CmdEnum::UNHOLD, "Held", stoppable);
+  }
+  static WaitState* Complete(QState* stoppable)
+  {
+    return new WaitState(StatesEnum::COMPLETE, CmdEnum::RESET, "Complete", stoppable);
+  }
+  static WaitState* Suspended(QState* stoppable)
+  {
+    return new WaitState(StatesEnum::SUSPENDED, CmdEnum::UNSUSPEND, "Suspended", stoppable);
+  }
+  static WaitState* Stopped(QState* abortable)
+  {
+    return new WaitState(StatesEnum::STOPPED, CmdEnum::RESET, "Stopped", abortable);
+  }
+  static WaitState* Aborted()
+  {
+    return new WaitState(StatesEnum::ABORTED, CmdEnum::CLEAR, "Aborted");
+  }
+
+  WaitState(StatesEnum state_value, CmdEnum exit_cmd_value, QString name_value) :
+    BaseState(state_value, name_value),
+    exit_cmd(exit_cmd_value)
+  {}
+
+  WaitState(StatesEnum state_value, CmdEnum exit_cmd_value, QString name_value, QState* super_state) :
+    BaseState(state_value, name_value, super_state),
+    exit_cmd(exit_cmd_value)
+  {}
+protected:
+  virtual void onEntry(QEvent *e)
+  {
+    ROS_INFO_STREAM("Entering state: " << name_.toStdString() << "(" << state_ <<")");
+  }
+  virtual void onExit(QEvent *e)
+  {
+    ROS_INFO_STREAM("Exiting state: " << name_.toStdString() << "(" << state_ << ")");
+  }
+
+private:
+  CmdEnum exit_cmd;
+};
+
+
+struct ActingState : public BaseState
+{
+public:
+
+  static ActingState* Resetting(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::RESETTING, "Resetting", stoppable, delay_ms_value);
+  }
+  static ActingState* Starting(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::STARTING, "Starting", stoppable, delay_ms_value);
+  }
+  static ActingState* Unholding(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::UNHOLDING, "Un-Holding", stoppable, delay_ms_value);
+  }
+  static ActingState* Unsuspending(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::UNSUSPENDING, "Un-Suspending", stoppable, delay_ms_value);
+  }
+  static ActingState* Holding(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::HOLDING, "Holding", stoppable, delay_ms_value);
+  }
+  static ActingState* Suspending(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::SUSPENDING, "Suspending", stoppable, delay_ms_value);
+  }
+  static ActingState* Execute(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::EXECUTE, "Exectue", stoppable, delay_ms_value);
+  }
+  static ActingState* Completing(QState* stoppable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::COMPLETING, "Completing", stoppable, delay_ms_value);
+  }
+  static ActingState* Aborting(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::ABORTING, "Aborting", delay_ms_value);
+  }
+  static ActingState* Clearing(QState* abortable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::CLEARING, "Clearing", abortable, delay_ms_value);
+  }
+  static ActingState* Stopping(QState* abortable, int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::STOPPING, "Aborting", abortable, delay_ms_value);
+  }
+
+  ActingState(StatesEnum state_value, const char* name_value, int delay_ms_value = 200) :
+    BaseState(state_value, QString(name_value)),
+    delay_ms(delay_ms_value)
+  {}
+
+  ActingState(StatesEnum state_value, const QString & name_value, QState* super_state, int delay_ms_value = 200) :
+    BaseState(state_value, name_value, super_state),
+    delay_ms(delay_ms_value)
+  {}
+protected:
+  virtual void onEntry(QEvent *e)
+  {
+
+    ROS_INFO_STREAM("Entering state: " << name_.toStdString() << "(" << state_ <<")");
+    StateCompleteEvent* sc = new StateCompleteEvent();
+    machine()->postDelayedEvent(sc, delay_ms);  //sc is deletecd by state machine
+  }
+
+  virtual void onExit(QEvent *e)
+  {
+    ROS_INFO_STREAM("Leaving state: " << name_.toStdString() << "(" << state_ <<")");
+  }
+private:
+  int delay_ms;
+};
+
 class StateMachine : public QStateMachine
 {
-  //Q_OBJECT
+  Q_OBJECT
 
 public:
   StateMachine();
+  StateMachine(BaseState* execute_state);
+  void init(BaseState* execute_state);
   virtual ~StateMachine();
 
 

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -1,0 +1,42 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <QtGui>
+#include "QEvent"
+#include "QAbstractTransition"
+
+namespace packml_sm
+{
+
+class StateMachine : public QStateMachine
+{
+  //Q_OBJECT
+
+public:
+  StateMachine();
+  virtual ~StateMachine();
+
+
+protected:
+  QThread worker_;
+
+};
+
+}

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -16,434 +16,27 @@
  * limitations under the License.
  */
 
-#pragma once
+
+#ifndef STATE_MACHINE_H
+#define STATE_MACHINE_H
 
 #include <QtGui>
 #include "QEvent"
 #include "QAbstractTransition"
 
-#include "packml_msgs/State.h"
-#include "packml_msgs/StateCommand.h"
+#include "packml_sm/state.h"
+#include "packml_sm/transitions.h"
+
 #include "ros/console.h"
 
 namespace packml_sm
 {
 
-//This magic function allows iostream (i.e. ROS_##_STREAM) macros to print out
-//enumerations
-//see: http://stackoverflow.com/questions/11421432/how-can-i-output-the-value-of-an-enum-class-in-c11
-template<typename T>
-std::ostream& operator<<(typename std::enable_if<std::is_enum<T>::value, std::ostream>::type& stream, const T& e)
-{
-  return stream << static_cast<typename std::underlying_type<T>::type>(e);
-}
 
 enum class StatesEnum;  //foward declaration of enum
 class StateMachine;
 
-struct PackmlState : public QState
-{
-  Q_OBJECT
 
-public:
-  PackmlState(StatesEnum state_value, QString name_value) :
-    state_(state_value),
-    name_(name_value),
-    cummulative_time_(0) {}
-
-  PackmlState(StatesEnum state_value, QString name_value, QState* super_state) :
-    QState(super_state),
-    state_(state_value),
-    name_(name_value),
-    cummulative_time_(0) {}
-
-  StatesEnum state() const {return state_;}
-  const QString name() const {return name_;}
-
-signals:
-  void stateEntered(int value, QString name);
-
-protected:
-  StatesEnum state_;
-  QString name_;
-
-  ros::Time enter_time_;
-  ros::Time exit_time_;
-  ros::Duration cummulative_time_;
-
-
-  virtual void onEntry(QEvent *e)
-  {
-    ROS_INFO_STREAM("Entering state: " << name_.toStdString() << "(" << state_ <<")");
-    emit stateEntered(static_cast<int>(state_), name_);
-    enter_time_ = ros::Time::now();
-    operation();
-  }
-
-  virtual void operation()
-  {
-  }
-
-  virtual void onExit(QEvent *e)
-  {
-    ROS_INFO_STREAM("Exiting state: " << name_.toStdString() << "(" << state_ << ")");
-    exit_time_ = ros::Time::now();
-    cummulative_time_ = cummulative_time_ + (exit_time_ - enter_time_);
-    ROS_INFO_STREAM("Updating cummulative time, for state: " << name_.toStdString() << "("
-                    << state_ << ") to: " << cummulative_time_.toSec());
-  }
-};
-
-
-static int PACKML_CMD_EVENT_TYPE = QEvent::User+1;
-static int PACKML_STATE_COMPLETE_EVENT_TYPE = QEvent::User+2;
-
-enum class StatesEnum {
-  UNDEFINED = 0,
-  OFF = 1,
-  STOPPED = 2,
-  STARTING = 3,
-  IDLE = 4,
-  SUSPENDED = 5,
-  EXECUTE = 6,
-  STOPPING = 7,
-  ABORTING = 8,
-  ABORTED = 9,
-  HOLDING = 10,
-  HELD = 11,
-
-  RESETTING = 100,
-  SUSPENDING = 101,
-  UNSUSPENDING = 102,
-  CLEARING = 103,
-  UNHOLDING = 104,
-  COMPLETING = 105,
-  COMPLETE = 106,
-
-  // Super states that encapsulate multiple substates with a common transition
-  // Not explicitly used in the standard but helpful for consutrcting the state
-  // machine.
-  ABORTABLE = 200,
-  STOPPABLE = 201
-};
-
-enum class ModeEnum {
-  UNDEFINED = 0,
-  AUTOMATIC = 1,
-  SEMI_AUTOMATIC = 2,
-  MANUAL = 3,
-  IDLE = 4,
-  SETUP = 11
-};
-
-enum class CmdEnum {
-  UNDEFINED = 0,
-  CLEAR = 1,
-  START = 2,
-  STOP = 3,
-  HOLD = 4,
-  ABORT = 5,
-  RESET = 6,
-  ESTOP = 7,
-
-  SUSPEND = 100,
-  UNSUSPEND = 101,
-  UNHOLD = 102
-};
-
-
-struct CmdEvent : public QEvent
-{
-  static CmdEvent* clear()
-  {
-    return new CmdEvent(CmdEnum::CLEAR);
-  }
-  static CmdEvent* start()
-  {
-    return new CmdEvent(CmdEnum::START);
-  }
-  static CmdEvent* stop()
-  {
-    return new CmdEvent(CmdEnum::STOP);
-  }
-  static CmdEvent* hold()
-  {
-    return new CmdEvent(CmdEnum::HOLD);
-  }
-  static CmdEvent* abort()
-  {
-    return new CmdEvent(CmdEnum::ABORT);
-  }
-  static CmdEvent* reset()
-  {
-    return new CmdEvent(CmdEnum::RESET);
-  }
-  static CmdEvent* estop()
-  {
-    return new CmdEvent(CmdEnum::ESTOP);
-  }
-  static CmdEvent* suspend()
-  {
-    return new CmdEvent(CmdEnum::SUSPEND);
-  }
-  static CmdEvent* unsuspend()
-  {
-    return new CmdEvent(CmdEnum::UNSUSPEND);
-  }
-  static CmdEvent* unhold()
-  {
-    return new CmdEvent(CmdEnum::UNHOLD);
-  }
-
-  CmdEvent(const CmdEnum &cmd_value)
-    : QEvent(QEvent::Type(PACKML_CMD_EVENT_TYPE)),
-      cmd(cmd_value) {}
-
-  CmdEnum cmd;
-};
-
-class CmdTransition : public QAbstractTransition
-{
-public:
-
-
-  static CmdTransition* clear(PackmlState & from, PackmlState & to)
-  {
-    return new CmdTransition(CmdEnum::CLEAR, "clear", from, to);
-  }
-  static CmdTransition* start(PackmlState & from, PackmlState & to)
-  {
-    return new CmdTransition(CmdEnum::START, "start", from, to);
-  }
-  static CmdTransition* stop(PackmlState & from, PackmlState & to)
-  {
-    return new CmdTransition(CmdEnum::STOP, "stop", from, to);
-  }
-  static CmdTransition* hold(PackmlState & from, PackmlState & to)
-  {
-    return new CmdTransition(CmdEnum::HOLD, "hold", from, to);
-  }
-  static CmdTransition* abort(PackmlState & from, PackmlState & to)
-  {
-    return new CmdTransition(CmdEnum::ABORT, "abort", from, to);
-  }
-  static CmdTransition* reset(PackmlState & from, PackmlState & to)
-  {
-    return new CmdTransition(CmdEnum::RESET, "reset", from, to);
-  }
-  static CmdTransition* estop(PackmlState & from, PackmlState & to)
-  {
-    return new CmdTransition(CmdEnum::ESTOP, "estop", from, to);
-  }
-  static CmdTransition* suspend(PackmlState & from, PackmlState & to)
-  {
-    return new CmdTransition(CmdEnum::SUSPEND, "abort", from, to);
-  }
-  static CmdTransition* unsuspend(PackmlState & from, PackmlState & to)
-  {
-    return new CmdTransition(CmdEnum::UNSUSPEND, "unsuspend", from, to);
-  }
-  static CmdTransition* unhold(PackmlState & from, PackmlState & to)
-  {
-    return new CmdTransition(CmdEnum::UNHOLD, "unhold", from, to);
-  }
-
-  CmdTransition(const CmdEnum &cmd_value, const QString &name_value) :
-    cmd(cmd_value),
-    name(name_value) {}
-
-
-  CmdTransition(const CmdEnum &cmd_value, const QString &name_value,
-                PackmlState & from, PackmlState & to) :
-    cmd(cmd_value),
-    name(name_value)
-  {
-    this->setTargetState(&to);
-    from.addTransition(this);
-    ROS_INFO_STREAM("Creating " << this->name.toStdString() << " transition from " <<
-                    from.name().toStdString() << " to " << to.name().toStdString());
-  }
-
-protected:
-
-
-  virtual bool eventTest(QEvent *e)
-  {
-//    ROS_INFO_STREAM("Testing event type: " << e->type());
-    if (e->type() != QEvent::Type(PACKML_CMD_EVENT_TYPE))
-      return false;
-    CmdEvent *se = static_cast<CmdEvent*>(e);
-//    ROS_INFO_STREAM("Type cmd: " << cmd << ", event cmd: " << se->cmd);
-    return (cmd == se->cmd);
-  }
-
-  virtual void onTransition(QEvent *e) {}
-
-  CmdEnum cmd;
-  QString name;
-};
-
-
-struct StateCompleteEvent : public QEvent
-{
-  StateCompleteEvent()
-    : QEvent(QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE)) {}
-};
-
-
-class StateCompleteTransition : public QAbstractTransition
-{
-public:
-  StateCompleteTransition() {}
-
-  StateCompleteTransition(PackmlState & from, PackmlState & to)
-  {
-    this->setTargetState(&to);
-    from.addTransition(this);
-    ROS_INFO_STREAM("Creating state complete transition from " <<
-                    from.name().toStdString() << " to " << to.name().toStdString());
-  }
-
-  ~StateCompleteTransition() {}
-
-protected:
-  virtual bool eventTest(QEvent *e)
-  {
-    if (e->type() != QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE))
-      return false;
-    return (true);
-  }
-
-  virtual void onTransition(QEvent *e) {}
-
-private:
-};
-
-struct WaitState : public PackmlState
-{
-public:
-
-  static WaitState* Abortable()
-  {
-    return new WaitState(StatesEnum::ABORTABLE, CmdEnum::ABORT, "Abortable");
-  }
-  static WaitState* Stoppable(QState* abortable)
-  {
-    return new WaitState(StatesEnum::STOPPABLE, CmdEnum::ABORT, "Stoppable", abortable);
-  }
-  static WaitState* Idle(QState* stoppable)
-  {
-    return new WaitState(StatesEnum::IDLE, CmdEnum::START, "Idle", stoppable);
-  }
-  static WaitState* Held(QState* stoppable)
-  {
-    return new WaitState(StatesEnum::HELD, CmdEnum::UNHOLD, "Held", stoppable);
-  }
-  static WaitState* Complete(QState* stoppable)
-  {
-    return new WaitState(StatesEnum::COMPLETE, CmdEnum::RESET, "Complete", stoppable);
-  }
-  static WaitState* Suspended(QState* stoppable)
-  {
-    return new WaitState(StatesEnum::SUSPENDED, CmdEnum::UNSUSPEND, "Suspended", stoppable);
-  }
-  static WaitState* Stopped(QState* abortable)
-  {
-    return new WaitState(StatesEnum::STOPPED, CmdEnum::RESET, "Stopped", abortable);
-  }
-  static WaitState* Aborted()
-  {
-    return new WaitState(StatesEnum::ABORTED, CmdEnum::CLEAR, "Aborted");
-  }
-
-  WaitState(StatesEnum state_value, CmdEnum exit_cmd_value, QString name_value) :
-    PackmlState(state_value, name_value),
-    exit_cmd(exit_cmd_value)
-  {}
-
-  WaitState(StatesEnum state_value, CmdEnum exit_cmd_value, QString name_value, QState* super_state) :
-    PackmlState(state_value, name_value, super_state),
-    exit_cmd(exit_cmd_value)
-  {}
-
-private:
-  CmdEnum exit_cmd;
-};
-
-
-struct ActingState : public PackmlState
-{
-public:
-
-  static ActingState* Resetting(QState* stoppable, int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::RESETTING, "Resetting", stoppable, delay_ms_value);
-  }
-  static ActingState* Starting(QState* stoppable, int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::STARTING, "Starting", stoppable, delay_ms_value);
-  }
-  static ActingState* Unholding(QState* stoppable, int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::UNHOLDING, "Un-Holding", stoppable, delay_ms_value);
-  }
-  static ActingState* Unsuspending(QState* stoppable, int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::UNSUSPENDING, "Un-Suspending", stoppable, delay_ms_value);
-  }
-  static ActingState* Holding(QState* stoppable, int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::HOLDING, "Holding", stoppable, delay_ms_value);
-  }
-  static ActingState* Suspending(QState* stoppable, int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::SUSPENDING, "Suspending", stoppable, delay_ms_value);
-  }
-  static ActingState* Execute(QState* stoppable, int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::EXECUTE, "Exectue", stoppable, delay_ms_value);
-  }
-  static ActingState* Completing(QState* stoppable, int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::COMPLETING, "Completing", stoppable, delay_ms_value);
-  }
-  static ActingState* Aborting(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::ABORTING, "Aborting", delay_ms_value);
-  }
-  static ActingState* Clearing(QState* abortable, int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::CLEARING, "Clearing", abortable, delay_ms_value);
-  }
-  static ActingState* Stopping(QState* abortable, int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::STOPPING, "Aborting", abortable, delay_ms_value);
-  }
-
-  ActingState(StatesEnum state_value, const char* name_value, int delay_ms_value = 200) :
-    PackmlState(state_value, QString(name_value)),
-    delay_ms(delay_ms_value)
-  {}
-
-  ActingState(StatesEnum state_value, const QString & name_value, QState* super_state, int delay_ms_value = 200) :
-    PackmlState(state_value, name_value, super_state),
-    delay_ms(delay_ms_value)
-  {}
-protected:
-  virtual void onEntry(QEvent *e)
-  {
-    PackmlState::onEntry(e);
-  }
-
-  virtual void operation()
-  {
-    StateCompleteEvent* sc = new StateCompleteEvent();
-    machine()->postDelayedEvent(sc, delay_ms);  //sc is deletecd by state machine
-  }
-
-private:
-  int delay_ms;
-};
 
 class StateMachine : public QStateMachine
 {
@@ -458,7 +51,7 @@ public:
     return state_value_;
   }
 
-  virtual ~StateMachine();
+  virtual ~StateMachine() {}
 
 
 protected:
@@ -467,14 +60,10 @@ protected:
   QString state_name_;
 
 protected slots:
-  void setState(int value, QString name)
-  {
-    ROS_INFO_STREAM("Current state changed to: " << name.toStdString() <<
-                    "(" << value << ")");
-    state_value_ = value;
-    state_name_ = name;
-  }
+  void setState(int value, QString name);
 
 };
 
 }
+
+#endif //STATE_MACHINE_H

--- a/packml_sm/include/packml_sm/transitions.h
+++ b/packml_sm/include/packml_sm/transitions.h
@@ -120,6 +120,25 @@ private:
 };
 
 
+class ErrorTransition : public QAbstractTransition
+{
+public:
+
+  ErrorTransition() {}
+
+  ErrorTransition(PackmlState & from, PackmlState & to);
+
+  ~ErrorTransition() {}
+
+protected:
+  virtual bool eventTest(QEvent *e);
+  virtual void onTransition(QEvent *e) {}
+
+
+private:
+};
+
+
 
 
 

--- a/packml_sm/include/packml_sm/transitions.h
+++ b/packml_sm/include/packml_sm/transitions.h
@@ -1,0 +1,127 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef TRANSITIONS_H
+#define TRANSITIONS_H
+
+
+#include <QtGui>
+#include "QEvent"
+#include "QAbstractTransition"
+
+#include "packml_sm/common.h"
+#include "packml_sm/state.h"
+
+#include "ros/console.h"
+
+namespace packml_sm
+{
+
+
+
+
+class CmdTransition : public QAbstractTransition
+{
+public:
+
+
+  static CmdTransition* clear(PackmlState & from, PackmlState & to)
+  {
+    return new CmdTransition(CmdEnum::CLEAR, "clear", from, to);
+  }
+  static CmdTransition* start(PackmlState & from, PackmlState & to)
+  {
+    return new CmdTransition(CmdEnum::START, "start", from, to);
+  }
+  static CmdTransition* stop(PackmlState & from, PackmlState & to)
+  {
+    return new CmdTransition(CmdEnum::STOP, "stop", from, to);
+  }
+  static CmdTransition* hold(PackmlState & from, PackmlState & to)
+  {
+    return new CmdTransition(CmdEnum::HOLD, "hold", from, to);
+  }
+  static CmdTransition* abort(PackmlState & from, PackmlState & to)
+  {
+    return new CmdTransition(CmdEnum::ABORT, "abort", from, to);
+  }
+  static CmdTransition* reset(PackmlState & from, PackmlState & to)
+  {
+    return new CmdTransition(CmdEnum::RESET, "reset", from, to);
+  }
+  static CmdTransition* estop(PackmlState & from, PackmlState & to)
+  {
+    return new CmdTransition(CmdEnum::ESTOP, "estop", from, to);
+  }
+  static CmdTransition* suspend(PackmlState & from, PackmlState & to)
+  {
+    return new CmdTransition(CmdEnum::SUSPEND, "abort", from, to);
+  }
+  static CmdTransition* unsuspend(PackmlState & from, PackmlState & to)
+  {
+    return new CmdTransition(CmdEnum::UNSUSPEND, "unsuspend", from, to);
+  }
+  static CmdTransition* unhold(PackmlState & from, PackmlState & to)
+  {
+    return new CmdTransition(CmdEnum::UNHOLD, "unhold", from, to);
+  }
+
+  CmdTransition(const CmdEnum &cmd_value, const QString &name_value) :
+    cmd(cmd_value),
+    name(name_value) {}
+
+
+  CmdTransition(const CmdEnum &cmd_value, const QString &name_value,
+                PackmlState & from, PackmlState & to);
+
+protected:
+
+
+  virtual bool eventTest(QEvent *e);
+  virtual void onTransition(QEvent *e) {}
+
+  CmdEnum cmd;
+  QString name;
+};
+
+
+
+
+class StateCompleteTransition : public QAbstractTransition
+{
+public:
+  StateCompleteTransition() {}
+
+  StateCompleteTransition(PackmlState & from, PackmlState & to);
+
+  ~StateCompleteTransition() {}
+
+protected:
+  virtual bool eventTest(QEvent *e);
+  virtual void onTransition(QEvent *e) {}
+
+private:
+};
+
+
+
+
+
+}
+#endif // TRANSITIONS_H

--- a/packml_sm/package.xml
+++ b/packml_sm/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package>
+  <name>packml_sm</name>
+  <version>0.0.0</version>
+  <description>Packml state machine</description>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <license>Apache 2.0</license>
+  <author >Shaun Edwards</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>rqt_gui</build_depend>
+  <build_depend>rqt_gui_cpp</build_depend>
+
+  <run_depend>rqt_gui</run_depend>
+  <run_depend>rqt_gui_cpp</run_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/packml_sm/src/state.cpp
+++ b/packml_sm/src/state.cpp
@@ -56,7 +56,7 @@ void ActingState::operation()
     else
     {
       ROS_ERROR_STREAM("Operational function returned error code: " << error_code);
-      sc = CmdEvent::abort();
+      sc = new ErrorEvent(error_code);
     }
   }
   else

--- a/packml_sm/src/state.cpp
+++ b/packml_sm/src/state.cpp
@@ -44,19 +44,19 @@ void PackmlState::onExit(QEvent *e)
 
 void ActingState::operation()
 {
+  if( function_ )
+  {
+    ROS_INFO_STREAM("Executing operational function in acting state");
+    function_();
+  }
+  else
+  {
+    ROS_INFO_STREAM("Default operation, delaying " << delay_ms << " ms");
+    ros::WallDuration(delay_ms/1000.0).sleep();
+    ROS_INFO_STREAM("Operation delay complete");
+  }
   StateCompleteEvent* sc = new StateCompleteEvent();
-  ROS_INFO_STREAM("Default operation, delaying " << delay_ms << " ms");
-  ros::WallDuration(delay_ms/1000.0).sleep();
-  ROS_INFO_STREAM("Operation delay complete");
   machine()->postEvent(sc);
 }
 
-void FunctionalState::operation()
-{
-  StateCompleteEvent* sc = new StateCompleteEvent();
-  function_();
-  machine()->postEvent(sc);
-}
-
-
-}
+}//packml_sm

--- a/packml_sm/src/state.cpp
+++ b/packml_sm/src/state.cpp
@@ -51,6 +51,12 @@ void ActingState::operation()
   machine()->postEvent(sc);
 }
 
+void FunctionalState::operation()
+{
+  StateCompleteEvent* sc = new StateCompleteEvent();
+  function_();
+  machine()->postEvent(sc);
+}
 
 
 }

--- a/packml_sm/src/state.cpp
+++ b/packml_sm/src/state.cpp
@@ -44,18 +44,28 @@ void PackmlState::onExit(QEvent *e)
 
 void ActingState::operation()
 {
+  QEvent* sc;
   if( function_ )
   {
     ROS_INFO_STREAM("Executing operational function in acting state");
-    function_();
+    int error_code = function_();
+    if( 0 == error_code )
+    {
+      sc = new StateCompleteEvent();
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Operational function returned error code: " << error_code);
+      sc = CmdEvent::abort();
+    }
   }
   else
   {
     ROS_INFO_STREAM("Default operation, delaying " << delay_ms << " ms");
     ros::WallDuration(delay_ms/1000.0).sleep();
     ROS_INFO_STREAM("Operation delay complete");
+    sc = new StateCompleteEvent();
   }
-  StateCompleteEvent* sc = new StateCompleteEvent();
   machine()->postEvent(sc);
 }
 

--- a/packml_sm/src/state.cpp
+++ b/packml_sm/src/state.cpp
@@ -1,0 +1,56 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "packml_sm/state.h"
+#include "packml_sm/events.h"
+
+namespace packml_sm
+{
+
+void PackmlState::onEntry(QEvent *e)
+{
+  ROS_INFO_STREAM("Entering state: " << name_.toStdString() << "(" << state_ <<")");
+  emit stateEntered(static_cast<int>(state_), name_);
+  enter_time_ = ros::Time::now();
+  operation();
+}
+
+
+void PackmlState::onExit(QEvent *e)
+{
+  ROS_INFO_STREAM("Exiting state: " << name_.toStdString() << "(" << state_ << ")");
+  exit_time_ = ros::Time::now();
+  cummulative_time_ = cummulative_time_ + (exit_time_ - enter_time_);
+  ROS_INFO_STREAM("Updating cummulative time, for state: " << name_.toStdString() << "("
+                  << state_ << ") to: " << cummulative_time_.toSec());
+}
+
+
+void ActingState::operation()
+{
+  StateCompleteEvent* sc = new StateCompleteEvent();
+  ROS_INFO_STREAM("Default operation, delaying " << delay_ms << " ms");
+  ros::WallDuration(delay_ms/1000.0).sleep();
+  ROS_INFO_STREAM("Operation delay complete");
+  machine()->postEvent(sc);
+}
+
+
+
+}

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -54,52 +54,92 @@ void StateMachine::init(BaseState* execute_state)
   ROS_INFO_STREAM("Forming state machine (states + transitions)");
   ROS_INFO_STREAM("Constructiong super states");
   BaseState* abortable_ = WaitState::Abortable();
+  connect(abortable_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* stoppable_ = WaitState::Stoppable(abortable_);
+  connect(stoppable_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   ROS_INFO_STREAM("Constructiong acting/wait states");
   BaseState* unholding_ = ActingState::Unholding(stoppable_);
+  connect(unholding_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* held_ = WaitState::Held(stoppable_);
+  connect(held_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* holding_ = ActingState::Holding(stoppable_);
+  connect(holding_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* idle_ = WaitState::Idle(stoppable_);
+  connect(idle_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* starting_ = ActingState::Starting(stoppable_);
+  connect(starting_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* completing_ = ActingState::Completing(stoppable_);
+  connect(completing_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* complete_ = WaitState::Complete(stoppable_);
+  connect(complete_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* resetting_ = ActingState::Resetting(stoppable_);
+  connect(resetting_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* unsuspending_ = ActingState::Unsuspending(stoppable_);
+  connect(unsuspending_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* suspended_ = WaitState::Suspended(stoppable_);
+  connect(suspended_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* suspending_ = ActingState::Suspending(stoppable_);
+  connect(suspending_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* stopped_ = WaitState::Stopped(abortable_);
+  connect(stopped_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* stopping_ = ActingState::Stopping(abortable_);
+  connect(stopping_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* clearing_ = ActingState::Clearing(abortable_);
+  connect(clearing_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* aborted_ = WaitState::Aborted();
+  connect(aborted_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   BaseState* aborting_ = ActingState::Aborting();
+  connect(aborting_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
   // special initialization for execute because it is passed in as a method
   // argument
   BaseState* execute_ = execute_state;
+  connect(execute_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
+
   execute_->setParent(stoppable_);
 
   ROS_INFO_STREAM("Construction and loading transitions");
 
   //Naming <from state>_<to state>
   //TODO: Still missing some transitions
-  CmdTransition* abortable_aborting = CmdTransition::abort(*abortable_, *aborting_);
-  StateCompleteTransition* aborting_aborted = new StateCompleteTransition(*aborting_, *aborted_);
-  CmdTransition* aborted_clearing_ = CmdTransition::clear(*aborted_, *clearing_);
-  StateCompleteTransition* clearing_stopped_ = new StateCompleteTransition(*clearing_, *stopped_);
-  CmdTransition* stoppable_stopping_ = CmdTransition::stop(*stoppable_, *stopping_);
-  StateCompleteTransition* unholding_execute_ = new StateCompleteTransition(*unholding_, *execute_);
-  CmdTransition* held_unholding_ = CmdTransition::unhold(*held_, *unholding_);
-  StateCompleteTransition* holding_held_ = new StateCompleteTransition(*holding_,*held_);
-  CmdTransition* idle_starting_ = CmdTransition::start(*idle_, *starting_);
-  StateCompleteTransition* starting_execute_ = new StateCompleteTransition(*starting_,*execute_);
-  CmdTransition* execute_holding_ = CmdTransition::hold(*execute_,*holding_);
-  StateCompleteTransition* execute_completing_ = new StateCompleteTransition(*execute_,*completing_);
-  CmdTransition* execute_suspending_ = CmdTransition::suspend(*execute_,*suspending_);
-  StateCompleteTransition* completing_complete = new StateCompleteTransition(*completing_, *complete_);
-  CmdTransition* complete_resetting_ = CmdTransition::reset(*complete_, *resetting_);
-  StateCompleteTransition* resetting_idle_ = new StateCompleteTransition(*resetting_, *idle_);
-  CmdTransition* suspended_unsuspending_ = CmdTransition::suspend(*suspended_, *unsuspending_);
-  StateCompleteTransition* unsuspending_execute_ = new StateCompleteTransition(*unsuspending_, *execute_);
+  CmdTransition*                abortable_aborting = CmdTransition::abort(*abortable_, *aborting_);
+  StateCompleteTransition*      aborting_aborted = new StateCompleteTransition(*aborting_, *aborted_);
+  CmdTransition*                aborted_clearing_ = CmdTransition::clear(*aborted_, *clearing_);
+  StateCompleteTransition*      clearing_stopped_ = new StateCompleteTransition(*clearing_, *stopped_);
+  CmdTransition*                stoppable_stopping_ = CmdTransition::stop(*stoppable_, *stopping_);
+  StateCompleteTransition*      stopping_stopped = new StateCompleteTransition(*stopping_, *stopped_);
+  CmdTransition*                stopped_resetting_ = CmdTransition::reset(*stopped_, *resetting_);
+  StateCompleteTransition*      unholding_execute_ = new StateCompleteTransition(*unholding_, *execute_);
+  CmdTransition*                held_unholding_ = CmdTransition::unhold(*held_, *unholding_);
+  StateCompleteTransition*      holding_held_ = new StateCompleteTransition(*holding_,*held_);
+  CmdTransition*                idle_starting_ = CmdTransition::start(*idle_, *starting_);
+  StateCompleteTransition*      starting_execute_ = new StateCompleteTransition(*starting_,*execute_);
+  CmdTransition*                execute_holding_ = CmdTransition::hold(*execute_,*holding_);
+  StateCompleteTransition*      execute_completing_ = new StateCompleteTransition(*execute_,*completing_);
+  StateCompleteTransition*      completing_complete = new StateCompleteTransition(*completing_, *complete_);
+  CmdTransition*                complete_resetting_ = CmdTransition::reset(*complete_, *resetting_);
+  StateCompleteTransition*      resetting_idle_ = new StateCompleteTransition(*resetting_, *idle_);
+  CmdTransition*                execute_suspending_ = CmdTransition::suspend(*execute_,*suspending_);
+  StateCompleteTransition*      suspending_suspended_ = new StateCompleteTransition(*suspending_,*suspended_);
+  CmdTransition*                suspended_unsuspending_ = CmdTransition::unsuspend(*suspended_, *unsuspending_);
+  StateCompleteTransition*      unsuspending_execute_ = new StateCompleteTransition(*unsuspending_, *execute_);
 
 
   ROS_INFO_STREAM("Adding states to state machine");

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -38,15 +38,17 @@ namespace packml_sm
 // that reference/utilize many of the same transitions/states (maybe)
 
 
-StateMachine::StateMachine(PackmlState* execute_state)
-{
-  init(execute_state);
-}
-
 StateMachine::StateMachine()
 {
-  init(ActingState::Execute(NULL));
 }
+
+
+bool StateMachine::init(std::function<void()> execute_method)
+{
+  ROS_INFO_STREAM("Initializing state machine with function pointer");
+  return init(FunctionalState::Execute(execute_method));
+}
+
 
 bool StateMachine::init(PackmlState* execute_state)
 {

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -123,6 +123,7 @@ bool StateMachine::init(std::function<int()> execute_method)
 
   //Naming <from state>_<to state>
   CmdTransition*                abortable_aborting = CmdTransition::abort(*abortable_, *aborting_);
+  ErrorTransition*              abortable_aborting_onerror = new ErrorTransition(*abortable_, *aborting_);
   StateCompleteTransition*      aborting_aborted = new StateCompleteTransition(*aborting_, *aborted_);
   CmdTransition*                aborted_clearing_ = CmdTransition::clear(*aborted_, *clearing_);
   StateCompleteTransition*      clearing_stopped_ = new StateCompleteTransition(*clearing_, *stopped_);

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "packml_sm/state_machine.h"
+#include "packml_sm/transitions.h"
 
 namespace packml_sm
 {
@@ -118,7 +119,6 @@ void StateMachine::init(PackmlState* execute_state)
   ROS_INFO_STREAM("Construction and loading transitions");
 
   //Naming <from state>_<to state>
-  //TODO: Still missing some transitions
   CmdTransition*                abortable_aborting = CmdTransition::abort(*abortable_, *aborting_);
   StateCompleteTransition*      aborting_aborted = new StateCompleteTransition(*aborting_, *aborted_);
   CmdTransition*                aborted_clearing_ = CmdTransition::clear(*aborted_, *clearing_);
@@ -151,8 +151,13 @@ void StateMachine::init(PackmlState* execute_state)
   setInitialState(aborted_);
   ROS_INFO_STREAM("State machine formed");
 }
-StateMachine::~StateMachine()
+
+void StateMachine::setState(int value, QString name)
 {
+  ROS_INFO_STREAM("State changed(event) to: " << name.toStdString() <<
+                  "(" << value << ")");
+  state_value_ = value;
+  state_name_ = name;
 }
 
 

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -43,7 +43,7 @@ StateMachine::StateMachine()
 }
 
 
-bool StateMachine::init(std::function<void()> execute_method)
+bool StateMachine::init(std::function<int()> execute_method)
 {
   ROS_INFO_STREAM("Checking if QCore application is running");
   if( NULL == QCoreApplication::instance() )
@@ -172,7 +172,7 @@ void StateMachine::setState(int value, QString name)
 }
 
 
-bool StateMachine::setExecute(std::function<void ()> execute_method)
+bool StateMachine::setExecute(std::function<int ()> execute_method)
 {
   ROS_INFO_STREAM("Initializing state machine with function pointer");
   return execute_->setOperationMethod(execute_method);

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -114,7 +114,7 @@ bool StateMachine::init(std::function<void()> execute_method)
 
   // special initialization for execute because it is passed in as a method
   // argument
-  execute_ = FunctionalState::Execute(execute_method);
+  execute_ = ActingState::Execute(execute_method);
   connect(execute_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
   execute_->setParent(stoppable_);

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -45,13 +45,6 @@ StateMachine::StateMachine()
 
 bool StateMachine::init(std::function<void()> execute_method)
 {
-  ROS_INFO_STREAM("Initializing state machine with function pointer");
-  return init(FunctionalState::Execute(execute_method));
-}
-
-
-bool StateMachine::init(PackmlState* execute_state)
-{
   ROS_INFO_STREAM("Checking if QCore application is running");
   if( NULL == QCoreApplication::instance() )
   {
@@ -121,7 +114,7 @@ bool StateMachine::init(PackmlState* execute_state)
 
   // special initialization for execute because it is passed in as a method
   // argument
-  PackmlState* execute_ = execute_state;
+  execute_ = FunctionalState::Execute(execute_method);
   connect(execute_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
   execute_->setParent(stoppable_);
@@ -178,5 +171,11 @@ void StateMachine::setState(int value, QString name)
   state_name_ = name;
 }
 
+
+bool StateMachine::setExecute(std::function<void ()> execute_method)
+{
+  ROS_INFO_STREAM("Initializing state machine with function pointer");
+  return execute_->setOperationMethod(execute_method);
+}
 
 }

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -17,228 +17,10 @@
  */
 
 #include "packml_sm/state_machine.h"
-#include "packml_msgs/State.h"
-#include "packml_msgs/StateCommand.h"
-#include "ros/console.h"
 
 namespace packml_sm
 {
 
-//This magic function allows iostream (i.e. ROS_##_STREAM) macros to print out
-//enumerations
-//see: http://stackoverflow.com/questions/11421432/how-can-i-output-the-value-of-an-enum-class-in-c11
-template<typename T>
-std::ostream& operator<<(typename std::enable_if<std::is_enum<T>::value, std::ostream>::type& stream, const T& e)
-{
-    return stream << static_cast<typename std::underlying_type<T>::type>(e);
-}
-
-static int PACKML_CMD_EVENT_TYPE = QEvent::User+1;
-static int PACKML_STATE_COMPLETE_EVENT_TYPE = QEvent::User+2;
-
-enum class StatesEnum {
-  UNDEFINED = 0,
-  OFF = 1,
-  STOPPED = 2,
-  STARTING = 3,
-  IDLE = 4,
-  SUSPENDED = 5,
-  EXECUTE = 6,
-  STOPPING = 7,
-  ABORTING = 8,
-  ABORTED = 9,
-  HOLDING = 10,
-  HELD = 11,
-
-  RESETTING = 100,
-  SUSPENDING = 101,
-  UNSUSPENDING = 102,
-  CLEARING = 103,
-  UNHOLDING = 104,
-  COMPLETING = 105,
-  COMPLETE = 106
-};
-
-enum class ModeEnum {
-  UNDEFINED = 0,
-  AUTOMATIC = 1,
-  SEMI_AUTOMATIC = 2,
-  MANUAL = 3,
-  IDLE = 4,
-  SETUP = 11
-};
-
-enum class CmdEnum {
-  UNDEFINED = 0,
-  CLEAR = 1,
-  START = 2,
-  STOP = 3,
-  HOLD = 4,
-  ABORT = 5,
-  RESET = 6,
-  ESTOP = 7,
-
-  SUSPEND = 100,
-  UNSUSPEND = 101,
-  UNHOLD = 102
-};
-
-struct CmdEvent : public QEvent
-{
-    CmdEvent(const int &cmd_value)
-    : QEvent(QEvent::Type(PACKML_CMD_EVENT_TYPE)),
-      cmd(cmd_value) {}
-
-    int cmd;
-};
-
-
-
-class CmdTransition : public QAbstractTransition
-{
-public:
-    CmdTransition(const int &cmd_value)
-        : cmd(cmd_value) {}
-
-protected:
-    virtual bool eventTest(QEvent *e)
-    {
-        if (e->type() != QEvent::Type(PACKML_CMD_EVENT_TYPE))
-            return false;
-        CmdEvent *se = static_cast<CmdEvent*>(e);
-        return (cmd == se->cmd);
-    }
-
-    virtual void onTransition(QEvent *e) {}
-
-private:
-    int cmd;
-};
-
-
-struct StateCompleteEvent : public QEvent
-{
-    StateCompleteEvent()
-    : QEvent(QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE)) {}
-};
-
-
-class StateCompleteTransition : public QAbstractTransition
-{
-public:
-    StateCompleteTransition() {}
-    ~StateCompleteTransition() {}
-
-protected:
-    virtual bool eventTest(QEvent *e)
-    {
-      if (e->type() != QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE))
-          return false;
-      return (true);
-    }
-
-    virtual void onTransition(QEvent *e) {}
-
-private:
-};
-
-struct BaseState : public QState
-{
-public:
-  BaseState(StatesEnum state_value, QString name_value) :
-    state(state_value),
-    name(name_value) {}
-
-protected:
-  StatesEnum state;
-  QString name;
-};
-
-struct WaitState : public BaseState
-{
-public:
-  WaitState(StatesEnum state_value, int exit_cmd_value, QString name_value) :
-    BaseState(state_value, name_value),
-    exit_cmd(exit_cmd_value)
-  {}
-protected:
-  virtual void onEntry(QEvent *e){}
-  virtual void onExit(QEvent *e){}
-private:
-  int exit_cmd;
-};
-
-
-struct ActingState : public BaseState
-{
-public:
-
-  static ActingState* Resetting(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::RESETTING, "Resetting", delay_ms_value);
-  }
-  static ActingState* Starting(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::STARTING, "Starting", delay_ms_value);
-  }
-  static ActingState* Unholding(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::UNHOLDING, "Un-Holding", delay_ms_value);
-  }
-  static ActingState* Unsuspending(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::UNSUSPENDING, "Un-Suspending", delay_ms_value);
-  }
-  static ActingState* Holding(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::HOLDING, "Holding", delay_ms_value);
-  }
-  static ActingState* Suspending(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::SUSPENDING, "Suspending", delay_ms_value);
-  }
-  static ActingState* Completing(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::COMPLETING, "Completing", delay_ms_value);
-  }
-  static ActingState* Aborting(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::ABORTING, "Aborting", delay_ms_value);
-  }
-  static ActingState* Clearing(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::CLEARING, "Clearing", delay_ms_value);
-  }
-  static ActingState* Stopping(int delay_ms_value = 200)
-  {
-    return new ActingState(StatesEnum::STOPPING, "Aborting", delay_ms_value);
-  }
-
-  ActingState(StatesEnum state_value, const char* name_value, int delay_ms_value = 200) :
-    BaseState(state_value, QString(name_value)),
-    delay_ms(delay_ms_value)
-  {}
-
-  ActingState(StatesEnum state_value, const QString & name_value, int delay_ms_value = 200) :
-    BaseState(state_value, name_value),
-    delay_ms(delay_ms_value)
-  {}
-protected:
-  virtual void onEntry(QEvent *e)
-  {
-
-    ROS_INFO_STREAM("Entering state: " << name.toStdString() << "(" << state <<")");
-    StateCompleteEvent* sc = new StateCompleteEvent();
-    machine()->postDelayedEvent(sc, delay_ms);  //sc is deletecd by state machine
-  }
-
-  virtual void onExit(QEvent *e)
-  {
-    ROS_INFO_STREAM("Leaving state: " << name.toStdString() << "(" << state <<")");
-  }
-private:
-  int delay_ms;
-};
 
 //NOTES:
 // Create factory methods that take std::bind as an argument for
@@ -255,44 +37,83 @@ private:
 // that reference/utilize many of the same transitions/states (maybe)
 
 
+StateMachine::StateMachine(BaseState* execute_state)
+{
+  init(execute_state);
+}
+
 StateMachine::StateMachine()
+{
+  init(ActingState::Execute(NULL));
+}
+
+void StateMachine::init(BaseState* execute_state)
 {
   ROS_INFO_STREAM("State machine constructor");
 
-//  QState* idle = new WaitState();
-//  QState* held = new WaitState();
   ROS_INFO_STREAM("Forming state machine (states + transitions)");
-  ROS_INFO_STREAM("Constructiong states");
-  QState* stopping = ActingState::Stopping();
-  QState* holding = ActingState::Holding();
+  ROS_INFO_STREAM("Constructiong super states");
+  BaseState* abortable_ = WaitState::Abortable();
+  BaseState* stoppable_ = WaitState::Stoppable(abortable_);
+  ROS_INFO_STREAM("Constructiong acting/wait states");
+  BaseState* unholding_ = ActingState::Unholding(stoppable_);
+  BaseState* held_ = WaitState::Held(stoppable_);
+  BaseState* holding_ = ActingState::Holding(stoppable_);
+  BaseState* idle_ = WaitState::Idle(stoppable_);
+  BaseState* starting_ = ActingState::Starting(stoppable_);
+  BaseState* completing_ = ActingState::Completing(stoppable_);
+  BaseState* complete_ = WaitState::Complete(stoppable_);
+  BaseState* resetting_ = ActingState::Resetting(stoppable_);
+  BaseState* unsuspending_ = ActingState::Unsuspending(stoppable_);
+  BaseState* suspended_ = WaitState::Suspended(stoppable_);
+  BaseState* suspending_ = ActingState::Suspending(stoppable_);
+  BaseState* stopped_ = WaitState::Stopped(abortable_);
+  BaseState* stopping_ = ActingState::Stopping(abortable_);
+  BaseState* clearing_ = ActingState::Clearing(abortable_);
+  BaseState* aborted_ = WaitState::Aborted();
+  BaseState* aborting_ = ActingState::Aborting();
+
+  // special initialization for execute because it is passed in as a method
+  // argument
+  BaseState* execute_ = execute_state;
+  execute_->setParent(stoppable_);
 
   ROS_INFO_STREAM("Construction and loading transitions");
 
-  StateCompleteTransition* stop_trans = new StateCompleteTransition();
-  stop_trans->setTargetState(holding);
-  stopping->addTransition(stop_trans);
-
-  StateCompleteTransition* hold_trans = new StateCompleteTransition();
-  hold_trans->setTargetState(stopping);
-  holding->addTransition(hold_trans);
+  //Naming <from state>_<to state>
+  //TODO: Still missing some transitions
+  CmdTransition* abortable_aborting = CmdTransition::abort(*abortable_, *aborting_);
+  StateCompleteTransition* aborting_aborted = new StateCompleteTransition(*aborting_, *aborted_);
+  CmdTransition* aborted_clearing_ = CmdTransition::clear(*aborted_, *clearing_);
+  StateCompleteTransition* clearing_stopped_ = new StateCompleteTransition(*clearing_, *stopped_);
+  CmdTransition* stoppable_stopping_ = CmdTransition::stop(*stoppable_, *stopping_);
+  StateCompleteTransition* unholding_execute_ = new StateCompleteTransition(*unholding_, *execute_);
+  CmdTransition* held_unholding_ = CmdTransition::unhold(*held_, *unholding_);
+  StateCompleteTransition* holding_held_ = new StateCompleteTransition(*holding_,*held_);
+  CmdTransition* idle_starting_ = CmdTransition::start(*idle_, *starting_);
+  StateCompleteTransition* starting_execute_ = new StateCompleteTransition(*starting_,*execute_);
+  CmdTransition* execute_holding_ = CmdTransition::hold(*execute_,*holding_);
+  StateCompleteTransition* execute_completing_ = new StateCompleteTransition(*execute_,*completing_);
+  CmdTransition* execute_suspending_ = CmdTransition::suspend(*execute_,*suspending_);
+  StateCompleteTransition* completing_complete = new StateCompleteTransition(*completing_, *complete_);
+  CmdTransition* complete_resetting_ = CmdTransition::reset(*complete_, *resetting_);
+  StateCompleteTransition* resetting_idle_ = new StateCompleteTransition(*resetting_, *idle_);
+  CmdTransition* suspended_unsuspending_ = CmdTransition::suspend(*suspended_, *unsuspending_);
+  StateCompleteTransition* unsuspending_execute_ = new StateCompleteTransition(*unsuspending_, *execute_);
 
 
   ROS_INFO_STREAM("Adding states to state machine");
-  addState(stopping);
-  addState(holding);
-  setInitialState(stopping);
+  addState(abortable_);
+  addState(aborted_);
+  addState(aborting_);
+  abortable_->setInitialState(clearing_);
+  stoppable_->setInitialState(resetting_);
+  setInitialState(aborted_);
   ROS_INFO_STREAM("State machine formed");
-  this->
-
-  moveToThread(&worker_);
-  worker_.start();
-
 }
 StateMachine::~StateMachine()
 {
 }
-
-
 
 
 }

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -1,0 +1,298 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "packml_sm/state_machine.h"
+#include "packml_msgs/State.h"
+#include "packml_msgs/StateCommand.h"
+#include "ros/console.h"
+
+namespace packml_sm
+{
+
+//This magic function allows iostream (i.e. ROS_##_STREAM) macros to print out
+//enumerations
+//see: http://stackoverflow.com/questions/11421432/how-can-i-output-the-value-of-an-enum-class-in-c11
+template<typename T>
+std::ostream& operator<<(typename std::enable_if<std::is_enum<T>::value, std::ostream>::type& stream, const T& e)
+{
+    return stream << static_cast<typename std::underlying_type<T>::type>(e);
+}
+
+static int PACKML_CMD_EVENT_TYPE = QEvent::User+1;
+static int PACKML_STATE_COMPLETE_EVENT_TYPE = QEvent::User+2;
+
+enum class StatesEnum {
+  UNDEFINED = 0,
+  OFF = 1,
+  STOPPED = 2,
+  STARTING = 3,
+  IDLE = 4,
+  SUSPENDED = 5,
+  EXECUTE = 6,
+  STOPPING = 7,
+  ABORTING = 8,
+  ABORTED = 9,
+  HOLDING = 10,
+  HELD = 11,
+
+  RESETTING = 100,
+  SUSPENDING = 101,
+  UNSUSPENDING = 102,
+  CLEARING = 103,
+  UNHOLDING = 104,
+  COMPLETING = 105,
+  COMPLETE = 106
+};
+
+enum class ModeEnum {
+  UNDEFINED = 0,
+  AUTOMATIC = 1,
+  SEMI_AUTOMATIC = 2,
+  MANUAL = 3,
+  IDLE = 4,
+  SETUP = 11
+};
+
+enum class CmdEnum {
+  UNDEFINED = 0,
+  CLEAR = 1,
+  START = 2,
+  STOP = 3,
+  HOLD = 4,
+  ABORT = 5,
+  RESET = 6,
+  ESTOP = 7,
+
+  SUSPEND = 100,
+  UNSUSPEND = 101,
+  UNHOLD = 102
+};
+
+struct CmdEvent : public QEvent
+{
+    CmdEvent(const int &cmd_value)
+    : QEvent(QEvent::Type(PACKML_CMD_EVENT_TYPE)),
+      cmd(cmd_value) {}
+
+    int cmd;
+};
+
+
+
+class CmdTransition : public QAbstractTransition
+{
+public:
+    CmdTransition(const int &cmd_value)
+        : cmd(cmd_value) {}
+
+protected:
+    virtual bool eventTest(QEvent *e)
+    {
+        if (e->type() != QEvent::Type(PACKML_CMD_EVENT_TYPE))
+            return false;
+        CmdEvent *se = static_cast<CmdEvent*>(e);
+        return (cmd == se->cmd);
+    }
+
+    virtual void onTransition(QEvent *e) {}
+
+private:
+    int cmd;
+};
+
+
+struct StateCompleteEvent : public QEvent
+{
+    StateCompleteEvent()
+    : QEvent(QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE)) {}
+};
+
+
+class StateCompleteTransition : public QAbstractTransition
+{
+public:
+    StateCompleteTransition() {}
+    ~StateCompleteTransition() {}
+
+protected:
+    virtual bool eventTest(QEvent *e)
+    {
+      if (e->type() != QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE))
+          return false;
+      return (true);
+    }
+
+    virtual void onTransition(QEvent *e) {}
+
+private:
+};
+
+struct BaseState : public QState
+{
+public:
+  BaseState(StatesEnum state_value, QString name_value) :
+    state(state_value),
+    name(name_value) {}
+
+protected:
+  StatesEnum state;
+  QString name;
+};
+
+struct WaitState : public BaseState
+{
+public:
+  WaitState(StatesEnum state_value, int exit_cmd_value, QString name_value) :
+    BaseState(state_value, name_value),
+    exit_cmd(exit_cmd_value)
+  {}
+protected:
+  virtual void onEntry(QEvent *e){}
+  virtual void onExit(QEvent *e){}
+private:
+  int exit_cmd;
+};
+
+
+struct ActingState : public BaseState
+{
+public:
+
+  static ActingState* Resetting(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::RESETTING, "Resetting", delay_ms_value);
+  }
+  static ActingState* Starting(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::STARTING, "Starting", delay_ms_value);
+  }
+  static ActingState* Unholding(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::UNHOLDING, "Un-Holding", delay_ms_value);
+  }
+  static ActingState* Unsuspending(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::UNSUSPENDING, "Un-Suspending", delay_ms_value);
+  }
+  static ActingState* Holding(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::HOLDING, "Holding", delay_ms_value);
+  }
+  static ActingState* Suspending(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::SUSPENDING, "Suspending", delay_ms_value);
+  }
+  static ActingState* Completing(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::COMPLETING, "Completing", delay_ms_value);
+  }
+  static ActingState* Aborting(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::ABORTING, "Aborting", delay_ms_value);
+  }
+  static ActingState* Clearing(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::CLEARING, "Clearing", delay_ms_value);
+  }
+  static ActingState* Stopping(int delay_ms_value = 200)
+  {
+    return new ActingState(StatesEnum::STOPPING, "Aborting", delay_ms_value);
+  }
+
+  ActingState(StatesEnum state_value, const char* name_value, int delay_ms_value = 200) :
+    BaseState(state_value, QString(name_value)),
+    delay_ms(delay_ms_value)
+  {}
+
+  ActingState(StatesEnum state_value, const QString & name_value, int delay_ms_value = 200) :
+    BaseState(state_value, name_value),
+    delay_ms(delay_ms_value)
+  {}
+protected:
+  virtual void onEntry(QEvent *e)
+  {
+
+    ROS_INFO_STREAM("Entering state: " << name.toStdString() << "(" << state <<")");
+    StateCompleteEvent* sc = new StateCompleteEvent();
+    machine()->postDelayedEvent(sc, delay_ms);  //sc is deletecd by state machine
+  }
+
+  virtual void onExit(QEvent *e)
+  {
+    ROS_INFO_STREAM("Leaving state: " << name.toStdString() << "(" << state <<")");
+  }
+private:
+  int delay_ms;
+};
+
+//NOTES:
+// Create factory methods that take std::bind as an argument for
+// a custom call back in the "onExit" method.
+
+// StateMachine will consist of several public SLOTS for each
+// PackML command.  The implementations will post events to the SM
+// when called.
+
+// Specializations of StateMachine (like ROS StateMachine) will use
+// state entered events to trigger status publishing via SLOTS
+
+// Mode handling will be achieved using a hiearchy of state machines
+// that reference/utilize many of the same transitions/states (maybe)
+
+
+StateMachine::StateMachine()
+{
+  ROS_INFO_STREAM("State machine constructor");
+
+//  QState* idle = new WaitState();
+//  QState* held = new WaitState();
+  ROS_INFO_STREAM("Forming state machine (states + transitions)");
+  ROS_INFO_STREAM("Constructiong states");
+  QState* stopping = ActingState::Stopping();
+  QState* holding = ActingState::Holding();
+
+  ROS_INFO_STREAM("Construction and loading transitions");
+
+  StateCompleteTransition* stop_trans = new StateCompleteTransition();
+  stop_trans->setTargetState(holding);
+  stopping->addTransition(stop_trans);
+
+  StateCompleteTransition* hold_trans = new StateCompleteTransition();
+  hold_trans->setTargetState(stopping);
+  holding->addTransition(hold_trans);
+
+
+  ROS_INFO_STREAM("Adding states to state machine");
+  addState(stopping);
+  addState(holding);
+  setInitialState(stopping);
+  ROS_INFO_STREAM("State machine formed");
+  this->
+
+  moveToThread(&worker_);
+  worker_.start();
+
+}
+StateMachine::~StateMachine()
+{
+}
+
+
+
+
+}

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -48,8 +48,16 @@ StateMachine::StateMachine()
   init(ActingState::Execute(NULL));
 }
 
-void StateMachine::init(PackmlState* execute_state)
+bool StateMachine::init(PackmlState* execute_state)
 {
+  ROS_INFO_STREAM("Checking if QCore application is running");
+  if( NULL == QCoreApplication::instance() )
+  {
+    ROS_ERROR_STREAM("QCore application is not running, QCoreApplication must"
+                    << " be created in main thread for state macine to run");
+    return false;
+  }
+
   ROS_INFO_STREAM("State machine constructor");
 
   ROS_INFO_STREAM("Forming state machine (states + transitions)");
@@ -150,6 +158,14 @@ void StateMachine::init(PackmlState* execute_state)
   stoppable_->setInitialState(resetting_);
   setInitialState(aborted_);
   ROS_INFO_STREAM("State machine formed");
+
+  ROS_INFO_STREAM("Moving state machine to Qcore thread");
+  this->moveToThread(QCoreApplication::instance()->thread());
+
+  start();
+  ROS_INFO_STREAM("State machine thread created and started");
+
+  return true;
 }
 
 void StateMachine::setState(int value, QString name)

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -37,7 +37,7 @@ namespace packml_sm
 // that reference/utilize many of the same transitions/states (maybe)
 
 
-StateMachine::StateMachine(BaseState* execute_state)
+StateMachine::StateMachine(PackmlState* execute_state)
 {
   init(execute_state);
 }
@@ -47,70 +47,70 @@ StateMachine::StateMachine()
   init(ActingState::Execute(NULL));
 }
 
-void StateMachine::init(BaseState* execute_state)
+void StateMachine::init(PackmlState* execute_state)
 {
   ROS_INFO_STREAM("State machine constructor");
 
   ROS_INFO_STREAM("Forming state machine (states + transitions)");
   ROS_INFO_STREAM("Constructiong super states");
-  BaseState* abortable_ = WaitState::Abortable();
+  PackmlState* abortable_ = WaitState::Abortable();
   connect(abortable_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* stoppable_ = WaitState::Stoppable(abortable_);
+  PackmlState* stoppable_ = WaitState::Stoppable(abortable_);
   connect(stoppable_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
   ROS_INFO_STREAM("Constructiong acting/wait states");
-  BaseState* unholding_ = ActingState::Unholding(stoppable_);
+  PackmlState* unholding_ = ActingState::Unholding(stoppable_);
   connect(unholding_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* held_ = WaitState::Held(stoppable_);
+  PackmlState* held_ = WaitState::Held(stoppable_);
   connect(held_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* holding_ = ActingState::Holding(stoppable_);
+  PackmlState* holding_ = ActingState::Holding(stoppable_);
   connect(holding_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* idle_ = WaitState::Idle(stoppable_);
+  PackmlState* idle_ = WaitState::Idle(stoppable_);
   connect(idle_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* starting_ = ActingState::Starting(stoppable_);
+  PackmlState* starting_ = ActingState::Starting(stoppable_);
   connect(starting_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* completing_ = ActingState::Completing(stoppable_);
+  PackmlState* completing_ = ActingState::Completing(stoppable_);
   connect(completing_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* complete_ = WaitState::Complete(stoppable_);
+  PackmlState* complete_ = WaitState::Complete(stoppable_);
   connect(complete_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* resetting_ = ActingState::Resetting(stoppable_);
+  PackmlState* resetting_ = ActingState::Resetting(stoppable_);
   connect(resetting_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* unsuspending_ = ActingState::Unsuspending(stoppable_);
+  PackmlState* unsuspending_ = ActingState::Unsuspending(stoppable_);
   connect(unsuspending_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* suspended_ = WaitState::Suspended(stoppable_);
+  PackmlState* suspended_ = WaitState::Suspended(stoppable_);
   connect(suspended_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* suspending_ = ActingState::Suspending(stoppable_);
+  PackmlState* suspending_ = ActingState::Suspending(stoppable_);
   connect(suspending_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* stopped_ = WaitState::Stopped(abortable_);
+  PackmlState* stopped_ = WaitState::Stopped(abortable_);
   connect(stopped_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* stopping_ = ActingState::Stopping(abortable_);
+  PackmlState* stopping_ = ActingState::Stopping(abortable_);
   connect(stopping_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* clearing_ = ActingState::Clearing(abortable_);
+  PackmlState* clearing_ = ActingState::Clearing(abortable_);
   connect(clearing_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* aborted_ = WaitState::Aborted();
+  PackmlState* aborted_ = WaitState::Aborted();
   connect(aborted_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
-  BaseState* aborting_ = ActingState::Aborting();
+  PackmlState* aborting_ = ActingState::Aborting();
   connect(aborting_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
   // special initialization for execute because it is passed in as a method
   // argument
-  BaseState* execute_ = execute_state;
+  PackmlState* execute_ = execute_state;
   connect(execute_, SIGNAL(stateEntered(int, QString)), this, SLOT(setState(int,QString)));
 
   execute_->setParent(stoppable_);

--- a/packml_sm/src/transitions.cpp
+++ b/packml_sm/src/transitions.cpp
@@ -58,4 +58,19 @@ bool CmdTransition::eventTest(QEvent *e)
   return (cmd == se->cmd);
 }
 
+ErrorTransition::ErrorTransition(PackmlState & from, PackmlState & to)
+{
+  this->setTargetState(&to);
+  from.addTransition(this);
+  ROS_INFO_STREAM("Creating error transition from " <<
+                  from.name().toStdString() << " to " << to.name().toStdString());
+}
+
+bool ErrorTransition::eventTest(QEvent *e)
+{
+  if (e->type() != QEvent::Type(PACKML_ERROR_EVENT_TYPE))
+    return false;
+  return (true);
+}
+
 }

--- a/packml_sm/src/transitions.cpp
+++ b/packml_sm/src/transitions.cpp
@@ -1,0 +1,61 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "packml_sm/transitions.h"
+#include "packml_sm/events.h"
+namespace packml_sm
+{
+
+StateCompleteTransition::StateCompleteTransition(PackmlState & from, PackmlState & to)
+{
+  this->setTargetState(&to);
+  from.addTransition(this);
+  ROS_INFO_STREAM("Creating state complete transition from " <<
+                  from.name().toStdString() << " to " << to.name().toStdString());
+}
+
+bool StateCompleteTransition::eventTest(QEvent *e)
+{
+  if (e->type() != QEvent::Type(PACKML_STATE_COMPLETE_EVENT_TYPE))
+    return false;
+  return (true);
+}
+
+
+CmdTransition::CmdTransition(const CmdEnum &cmd_value, const QString &name_value,
+              PackmlState & from, PackmlState & to) :
+  cmd(cmd_value),
+  name(name_value)
+{
+  this->setTargetState(&to);
+  from.addTransition(this);
+  ROS_INFO_STREAM("Creating " << this->name.toStdString() << " transition from " <<
+                  from.name().toStdString() << " to " << to.name().toStdString());
+}
+
+bool CmdTransition::eventTest(QEvent *e)
+{
+//    ROS_INFO_STREAM("Testing event type: " << e->type());
+  if (e->type() != QEvent::Type(PACKML_CMD_EVENT_TYPE))
+    return false;
+  CmdEvent *se = static_cast<CmdEvent*>(e);
+//    ROS_INFO_STREAM("Type cmd: " << cmd << ", event cmd: " << se->cmd);
+  return (cmd == se->cmd);
+}
+
+}

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -17,6 +17,8 @@
  */
 
 #include <gtest/gtest.h>
+#include "packml_sm/common.h"
+#include "packml_sm/events.h"
 #include "packml_sm/state_machine.h"
 #include "ros/duration.h"
 #include "ros/console.h"

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -53,6 +53,13 @@ bool waitForState(StatesEnum state, StateMachine & sm)
   return false;
 }
 
+void execute()
+{
+  ROS_INFO_STREAM("Beginning execute method");
+  ros::Duration(1.0).sleep();
+  ROS_INFO_STREAM("Execute method complete");
+}
+
 
 
 TEST(Packml_SM, construction)
@@ -66,6 +73,8 @@ TEST(Packml_SM, state_diagram)
 {
   ROS_INFO_STREAM("State diagram");
   StateMachine sm;
+  EXPECT_FALSE(sm.isActive());
+  sm.init(std::bind(execute));
   ros::Duration(1.0).sleep();  //give time to start
   EXPECT_TRUE(sm.isActive());
 

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -20,29 +20,106 @@
 #include "packml_sm/state_machine.h"
 #include "ros/duration.h"
 #include "ros/console.h"
+#include "ros/rate.h"
 
 namespace packml_sm_test
 {
 
 using namespace packml_sm;
 
+/**
+ * @brief waitForState - returns true if the current state of the state machine (sm) matches the queried state
+ * @param state - state enumeration to wait for
+ * @param sm - top level state machine
+ * @return true if state changes to queried state before internal timeout
+ */
+bool waitForState(StatesEnum state, StateMachine & sm)
+{
+  const double TIMEOUT = 2.0;
+  const int SAMPLES = 50;
+  ros::Rate r(double(SAMPLES)/TIMEOUT);
+  for(int ii=0; ii<SAMPLES; ++ii)
+  {
+    if(sm.getCurrentState() == static_cast<int>(state))
+    {
+      ROS_INFO_STREAM("State changed to " << state);
+      return true;
+    }
+    ROS_INFO_STREAM("Waiting for state to change to " << state);
+    r.sleep();
+  }
+  return false;
+}
+
+
+
 TEST(Packml_SM, construction)
 {
   ROS_INFO_STREAM("Construction test");
   StateMachine sm;
+}
+
+TEST(Packml_SM, state_diagram)
+{
+  ROS_INFO_STREAM("State diagram");
+  StateMachine sm;
   sm.moveToThread(QCoreApplication::instance()->thread());
   EXPECT_FALSE(sm.isRunning());
   sm.start();
-  ROS_INFO("Gave command to start sm");
-  ros::Duration(1).sleep();
-  EXPECT_TRUE(sm.isRunning());
+
+  ASSERT_TRUE(waitForState(StatesEnum::ABORTED, sm));
+  ASSERT_TRUE(sm.isRunning());
+
   sm.postEvent(CmdEvent::clear());
-  QCoreApplication::instance()->processEvents();
-  ROS_INFO("Called process events");
+  ASSERT_TRUE(waitForState(StatesEnum::CLEARING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::STOPPED, sm));
+
+  sm.postEvent(CmdEvent::reset());
+  ASSERT_TRUE(waitForState(StatesEnum::RESETTING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::IDLE, sm));
+
+  sm.postEvent(CmdEvent::start());
+  ASSERT_TRUE(waitForState(StatesEnum::STARTING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::EXECUTE, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::COMPLETING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::COMPLETE, sm));
+
+  sm.postEvent(CmdEvent::reset());
+  ASSERT_TRUE(waitForState(StatesEnum::RESETTING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::IDLE, sm));
+
+  sm.postEvent(CmdEvent::start());
+  ASSERT_TRUE(waitForState(StatesEnum::STARTING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::EXECUTE, sm));
+
+  sm.postEvent(CmdEvent::hold());
+  ASSERT_TRUE(waitForState(StatesEnum::HOLDING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::HELD, sm));
+
+  sm.postEvent(CmdEvent::unhold());
+  ASSERT_TRUE(waitForState(StatesEnum::UNHOLDING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::EXECUTE, sm));
+
+  sm.postEvent(CmdEvent::suspend());
+  ASSERT_TRUE(waitForState(StatesEnum::SUSPENDING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::SUSPENDED, sm));
+
+  sm.postEvent(CmdEvent::unsuspend());
+  ASSERT_TRUE(waitForState(StatesEnum::UNSUSPENDING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::EXECUTE, sm));
+
+  sm.postEvent(CmdEvent::stop());
+  ASSERT_TRUE(waitForState(StatesEnum::STOPPING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::STOPPED, sm));
+
+  sm.postEvent(CmdEvent::abort());
+  ASSERT_TRUE(waitForState(StatesEnum::ABORTING, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::ABORTED, sm));
+
   sm.stop();
   ros::Duration(1).sleep();
   EXPECT_FALSE(sm.isRunning());
-  ROS_INFO_STREAM("Construction test complete");
+  ROS_INFO_STREAM("State diagram test complete");
 }
 
 }

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -53,18 +53,20 @@ bool waitForState(StatesEnum state, StateMachine & sm)
   return false;
 }
 
-void execute1()
+int success()
 {
-  ROS_INFO_STREAM("Beginning execute(1) method");
+  ROS_INFO_STREAM("Beginning success() method");
   ros::Duration(1.0).sleep();
   ROS_INFO_STREAM("Execute method complete");
+  return 0;
 }
 
-void execute2()
+int fail()
 {
-  ROS_INFO_STREAM("Beginning execute(2) method");
+  ROS_INFO_STREAM("Beginning fail method");
   ros::Duration(1.0).sleep();
   ROS_INFO_STREAM("Execute method complete");
+  return -1;
 }
 
 
@@ -81,7 +83,7 @@ TEST(Packml_SM, state_diagram)
   ROS_INFO_STREAM("State diagram");
   StateMachine sm;
   EXPECT_FALSE(sm.isActive());
-  sm.init(std::bind(execute1));
+  sm.init(std::bind(success));
   ros::Duration(1.0).sleep();  //give time to start
   EXPECT_TRUE(sm.isActive());
 
@@ -144,7 +146,7 @@ TEST(Packml_SM, state_diagram)
 TEST(Packml_SM, set_execute)
 {
   StateMachine sm;
-  sm.init(std::bind(execute1));
+  sm.init(std::bind(success));
   ros::Duration(1.0).sleep();  //give time to start
   sm.postEvent(CmdEvent::clear());
   ASSERT_TRUE(waitForState(StatesEnum::STOPPED, sm));
@@ -154,9 +156,9 @@ TEST(Packml_SM, set_execute)
   ASSERT_TRUE(waitForState(StatesEnum::COMPLETE, sm));
   sm.postEvent(CmdEvent::reset());
   ASSERT_TRUE(waitForState(StatesEnum::IDLE, sm));
-  sm.setExecute(std::bind(execute2));
+  sm.setExecute(std::bind(fail));
   sm.postEvent(CmdEvent::start());
-  ASSERT_TRUE(waitForState(StatesEnum::COMPLETE, sm));
+  ASSERT_TRUE(waitForState(StatesEnum::ABORTED, sm));
 }
 
 }

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -1,0 +1,43 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "packml_sm/state_machine.h"
+#include "ros/duration.h"
+#include "ros/console.h"
+
+namespace packml_sm_test
+{
+
+using namespace packml_sm;
+
+TEST(Packml_SM, construction)
+{
+  ROS_INFO_STREAM("Construction test");
+  StateMachine sm;
+  EXPECT_FALSE(sm.isRunning());
+  sm.start();
+  ros::Duration(1).sleep();
+  EXPECT_TRUE(sm.isRunning());
+  sm.stop();
+  ros::Duration(1).sleep();
+  EXPECT_FALSE(sm.isRunning());
+  ROS_INFO_STREAM("Construction test complete");
+}
+
+}

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -53,9 +53,16 @@ bool waitForState(StatesEnum state, StateMachine & sm)
   return false;
 }
 
-void execute()
+void execute1()
 {
-  ROS_INFO_STREAM("Beginning execute method");
+  ROS_INFO_STREAM("Beginning execute(1) method");
+  ros::Duration(1.0).sleep();
+  ROS_INFO_STREAM("Execute method complete");
+}
+
+void execute2()
+{
+  ROS_INFO_STREAM("Beginning execute(2) method");
   ros::Duration(1.0).sleep();
   ROS_INFO_STREAM("Execute method complete");
 }
@@ -74,7 +81,7 @@ TEST(Packml_SM, state_diagram)
   ROS_INFO_STREAM("State diagram");
   StateMachine sm;
   EXPECT_FALSE(sm.isActive());
-  sm.init(std::bind(execute));
+  sm.init(std::bind(execute1));
   ros::Duration(1.0).sleep();  //give time to start
   EXPECT_TRUE(sm.isActive());
 
@@ -131,6 +138,25 @@ TEST(Packml_SM, state_diagram)
   ros::Duration(1).sleep();
   EXPECT_FALSE(sm.isActive());
   ROS_INFO_STREAM("State diagram test complete");
+}
+
+
+TEST(Packml_SM, set_execute)
+{
+  StateMachine sm;
+  sm.init(std::bind(execute1));
+  ros::Duration(1.0).sleep();  //give time to start
+  sm.postEvent(CmdEvent::clear());
+  ASSERT_TRUE(waitForState(StatesEnum::STOPPED, sm));
+  sm.postEvent(CmdEvent::reset());
+  ASSERT_TRUE(waitForState(StatesEnum::IDLE, sm));
+  sm.postEvent(CmdEvent::start());
+  ASSERT_TRUE(waitForState(StatesEnum::COMPLETE, sm));
+  sm.postEvent(CmdEvent::reset());
+  ASSERT_TRUE(waitForState(StatesEnum::IDLE, sm));
+  sm.setExecute(std::bind(execute2));
+  sm.postEvent(CmdEvent::start());
+  ASSERT_TRUE(waitForState(StatesEnum::COMPLETE, sm));
 }
 
 }

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -59,18 +59,18 @@ TEST(Packml_SM, construction)
 {
   ROS_INFO_STREAM("Construction test");
   StateMachine sm;
+  ros::Duration(1.0).sleep(); //immediate destruction causes seg fault
 }
 
 TEST(Packml_SM, state_diagram)
 {
   ROS_INFO_STREAM("State diagram");
   StateMachine sm;
-  sm.moveToThread(QCoreApplication::instance()->thread());
-  EXPECT_FALSE(sm.isRunning());
-  sm.start();
+  ros::Duration(1.0).sleep();  //give time to start
+  EXPECT_TRUE(sm.isActive());
 
   ASSERT_TRUE(waitForState(StatesEnum::ABORTED, sm));
-  ASSERT_TRUE(sm.isRunning());
+  ASSERT_TRUE(sm.isActive());
 
   sm.postEvent(CmdEvent::clear());
   ASSERT_TRUE(waitForState(StatesEnum::CLEARING, sm));
@@ -120,7 +120,7 @@ TEST(Packml_SM, state_diagram)
 
   sm.stop();
   ros::Duration(1).sleep();
-  EXPECT_FALSE(sm.isRunning());
+  EXPECT_FALSE(sm.isActive());
   ROS_INFO_STREAM("State diagram test complete");
 }
 

--- a/packml_sm/test/state_machine.cpp
+++ b/packml_sm/test/state_machine.cpp
@@ -30,10 +30,15 @@ TEST(Packml_SM, construction)
 {
   ROS_INFO_STREAM("Construction test");
   StateMachine sm;
+  sm.moveToThread(QCoreApplication::instance()->thread());
   EXPECT_FALSE(sm.isRunning());
   sm.start();
+  ROS_INFO("Gave command to start sm");
   ros::Duration(1).sleep();
   EXPECT_TRUE(sm.isRunning());
+  sm.postEvent(CmdEvent::clear());
+  QCoreApplication::instance()->processEvents();
+  ROS_INFO("Called process events");
   sm.stop();
   ros::Duration(1).sleep();
   EXPECT_FALSE(sm.isRunning());

--- a/packml_sm/test/utest.cpp
+++ b/packml_sm/test/utest.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016, Shaun Edwards, PlusOne Robotics
+ * All rights reserved.
+ */
+
+#include <gtest/gtest.h>
+#include <ros/time.h>
+#include <QCoreApplication>
+#include <QTimer>
+#include <boost/thread/thread.hpp>
+
+void qtWorker(int argc, char *argv[])
+{
+    QCoreApplication a(argc, argv);
+    a.exec();
+}
+
+int main(int argc, char **argv)
+{
+  boost::thread* thr = new boost::thread(&qtWorker, argc, argv);
+  ros::Time::init();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/packml_sm/test/utest.cpp
+++ b/packml_sm/test/utest.cpp
@@ -8,6 +8,7 @@
 #include <QCoreApplication>
 #include <QTimer>
 #include <boost/thread/thread.hpp>
+#include <ros/console.h>
 
 void qtWorker(int argc, char *argv[])
 {
@@ -19,6 +20,10 @@ int main(int argc, char **argv)
 {
   boost::thread* thr = new boost::thread(&qtWorker, argc, argv);
   ros::Time::init();
+  while(NULL == QCoreApplication::instance())
+  {
+    ROS_INFO_STREAM_THROTTLE(0.1, "Waiting for QCore application to start");
+  }
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This PR is an initial implementation of a PackML C++ (mostly ROS independent) library using the QT [state machine library](http://doc.qt.io/qt-4.8/statemachine-api.html).  The primary benefit of the QT state machine is that it supports state grouping, hierarchy, and parallel states.  Many of these concepts are used in the PackML standard (see diagram below). The QT signals/slots will also be very helpful in creating a completely separate ROS wrapper with event based publishers.    The downside is the QT event handling/threading model needs to be handled appropriately (partially handled at this point).  It's also unclear how much thread safety needs to be built into the library (depends on the amount of non-QT thread access that is required).

The `StateMachineInterface` represents the primary interface to the PackML state machine.  The interface should hide all QT implementation details, so that it could be reused for other implementations.  The interface allows "state overriding" by passing function pointers.  This is only supported for the execute method at this point, but other state overrides could be added as needed.  Use of the state machine object does not require any inheritance.  

The unit tests illustrate how the state machine is intended to be constructed and executed (in a background thread-the QT core application thread).  The next step is to create a ROS wrapper that proves out the implementation details.

![image](https://cloud.githubusercontent.com/assets/2932571/22907446/c6f58eee-f20e-11e6-9859-d72e6fa11d71.png)
