### PR TITLE
[packml_sm] Clearer dependency. Remove rqt.

### DIFF
--- a/packml_sm/CMakeLists.txt
+++ b/packml_sm/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(packml_sm)
-find_package(catkin REQUIRED rqt_gui rqt_gui_cpp)
+
+find_package(catkin REQUIRED roscpp qt_gui qt_gui_cpp)
 
 if("${qt_gui_cpp_USE_QT_MAJOR_VERSION} " STREQUAL "5 ")
   find_package(Qt5Widgets REQUIRED)
@@ -33,7 +34,7 @@ set(packml_sm_INCLUDE_DIRECTORIES
 catkin_package(
   INCLUDE_DIRS ${packml_sm_INCLUDE_DIRECTORIES}
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS rqt_gui rqt_gui_cpp
+  CATKIN_DEPENDS qt_gui qt_gui_cpp
   DEPENDS
 )
 

--- a/packml_sm/include/packml_sm/state.h
+++ b/packml_sm/include/packml_sm/state.h
@@ -24,7 +24,6 @@
 #include <QtGui>
 #include "QState"
 #include "QEvent"
-#include "QAbstractTransition"
 
 #include "ros/console.h"
 #include "packml_sm/common.h"

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -23,8 +23,6 @@
 #include <functional>
 
 #include <QtGui>
-#include "QEvent"
-#include "QAbstractTransition"
 
 #include "packml_sm/state.h"
 #include "packml_sm/transitions.h"

--- a/packml_sm/include/packml_sm/transitions.h
+++ b/packml_sm/include/packml_sm/transitions.h
@@ -21,7 +21,6 @@
 #define TRANSITIONS_H
 
 
-#include <QtGui>
 #include "QEvent"
 #include "QAbstractTransition"
 

--- a/packml_sm/package.xml
+++ b/packml_sm/package.xml
@@ -9,12 +9,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>rqt_gui</build_depend>
-  <build_depend>rqt_gui_cpp</build_depend>
+  <build_depend>qt_gui</build_depend>
+  <build_depend>qt_gui_cpp</build_depend>
+  <build_depend>roscpp</build_depend>
 
-  <run_depend>rqt_gui</run_depend>
-  <run_depend>rqt_gui_cpp</run_depend>
-
+  <run_depend>qt_gui</run_depend>
+  <run_depend>qt_gui_cpp</run_depend>
+  <run_depend>roscpp</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Toward https://github.com/ros-industrial-consortium/packml/issues/23, I'm learning the code. If I understand correctly, packml_sm package seems to be an implementation of `packml` and the rest in packml repo (i.e. `packml_{gui, msgs, ros}`) are ROS and/or rqt binding of it.

If that is correct, it'd be cleaner and easier for maintenance for packml_sm to be ROS/rqt-agnostic.
Although with this PR `roscpp` remains in use, it looks to be relatively easy to remove roscpp as well. If that's possible packml_sm can be ROS-agnostic, more standalone library.

If this is mergeable, should be done so backward to `indigo-devel`.