### PR TITLE
Add the capability to reset and retrieve duration stats.

### DIFF
--- a/packml_ros/include/packml_ros/packml_ros.h
+++ b/packml_ros/include/packml_ros/packml_ros.h
@@ -23,6 +23,7 @@
 #include <ros/ros.h>
 #include <packml_msgs/Status.h>
 #include <packml_msgs/Transition.h>
+#include <packml_msgs/ResetStats.h>
 #include <packml_sm/state_machine.h>
 
 
@@ -45,6 +46,8 @@ protected:
 
     bool transRequest(packml_msgs::Transition::Request &req,
                       packml_msgs::Transition::Response &res);
+    bool resetStatsRequest(packml_msgs::ResetStats::Request &req,
+                            packml_msgs::ResetStats::Response &res);
 
     ros::NodeHandle nh_;
     ros::NodeHandle pn_;
@@ -52,6 +55,7 @@ protected:
 
     ros::Publisher status_pub_;
     ros::ServiceServer trans_server_;
+    ros::ServiceServer reset_stats_;
 
     packml_msgs::Status status_msg_;
 

--- a/packml_ros/src/packml_ros.cpp
+++ b/packml_ros/src/packml_ros.cpp
@@ -33,6 +33,8 @@ PackmlRos::PackmlRos(ros::NodeHandle nh, ros::NodeHandle pn,
   trans_server_ = packml_node.advertiseService("transition", &PackmlRos::transRequest, this);
   status_msg_ = packml_msgs::initStatus(pn.getNamespace());
 
+  reset_stats_ = packml_node.advertiseService("reset_stats", &PackmlRos::resetStatsRequest, this);
+
   connect(sm.get(), SIGNAL(stateChanged(int, QString)), this, SLOT(pubState(int, QString)));
 }
 
@@ -146,5 +148,66 @@ bool PackmlRos::transRequest(packml_msgs::Transition::Request &req,
   }
 
 }
+bool PackmlRos::resetStatsRequest(packml_msgs::ResetStats::Request &req,
+                                           packml_msgs::ResetStats::Response &res)
+{
+  ros::Duration tmp_duration;
+  ros::Duration full_duration;
+
+  // Idle time
+  tmp_duration = sm_->getIdleTime();
+  tmp_duration += sm_->getStartingTime();
+  tmp_duration += sm_->getResettingTime();
+
+  res.last_stat.idle_duration.data = tmp_duration;
+  full_duration = tmp_duration;
+
+  // Execute time
+  tmp_duration = sm_->getExecuteTime();
+  res.last_stat.exe_duration.data = tmp_duration;
+  full_duration += tmp_duration;
+
+  // Held time
+  tmp_duration = sm_->getHeldTime();
+  tmp_duration += sm_->getHoldingTime();
+  tmp_duration += sm_->getUnholdingTime();
+
+  res.last_stat.held_duration.data = tmp_duration;
+  full_duration += tmp_duration;
+  // Suspended time
+  tmp_duration = sm_->getSuspendedTime();
+  tmp_duration += sm_->getSuspendingTime();
+  tmp_duration += sm_->getUnsuspendingTime();
+
+  res.last_stat.susp_duration.data = tmp_duration;
+  full_duration += tmp_duration;
+
+  // Complete time
+  tmp_duration = sm_->getCompleteTime();
+  tmp_duration += sm_->getCompletingTime();
+
+  res.last_stat.cmplt_duration.data = tmp_duration;
+  full_duration += tmp_duration;
+
+  // Stopped time
+  tmp_duration = sm_->getStoppedTime();
+  tmp_duration += sm_->getClearingTime();
+  tmp_duration += sm_->getStoppingTime();
+
+  res.last_stat.stop_duration.data = tmp_duration;
+  full_duration += tmp_duration;
+
+  // Aborted time
+  tmp_duration = sm_->getAbortedTime();
+  tmp_duration += sm_->getAbortingTime();
+
+  res.last_stat.abort_duration.data = tmp_duration;
+  full_duration += tmp_duration;
+
+  res.last_stat.duration.data = full_duration;
+  res.success = true;
+
+}
+
 
 } // namespace kitsune_robot

--- a/packml_sm/include/packml_sm/state.h
+++ b/packml_sm/include/packml_sm/state.h
@@ -40,16 +40,37 @@ public:
   PackmlState(StatesEnum state_value, QString name_value) :
     state_(state_value),
     name_(name_value),
+    running_(false),
     cummulative_time_(0) {}
 
   PackmlState(StatesEnum state_value, QString name_value, QState* super_state) :
     QState(super_state),
     state_(state_value),
     name_(name_value),
+    running_(false),
     cummulative_time_(0) {}
 
   StatesEnum state() const {return state_;}
   const QString name() const {return name_;}
+  ros::Duration getCummulativeTime() 
+  {
+    ros::Duration cummul;
+    ros::Time now = ros::Time::now();
+    if(running_)
+    {
+      cummul = cummulative_time_ + (now-enter_time_);
+      enter_time_ = now;
+      cummulative_time_ = ros::Duration(0);
+    }
+    else
+    {
+      cummul = cummulative_time_;
+      cummulative_time_ = ros::Duration(0);
+    }
+    return cummul;
+  }
+
+  void stopRunning() {running_ = false;}
 
 signals:
   void stateEntered(int value, QString name);
@@ -57,6 +78,7 @@ signals:
 protected:
   StatesEnum state_;
   QString name_;
+  bool running_;
 
   ros::Time enter_time_;
   ros::Time exit_time_;

--- a/packml_sm/include/packml_sm/state_machine.h
+++ b/packml_sm/include/packml_sm/state_machine.h
@@ -119,6 +119,24 @@ public:
     return state_value_;
   }
 
+  ros::Duration getIdleTime() {return idle_->getCummulativeTime();}
+  ros::Duration getStartingTime() {return starting_->getCummulativeTime();}
+  ros::Duration getExecuteTime() {return execute_->getCummulativeTime();}
+  ros::Duration getCompletingTime() {return completing_->getCummulativeTime();}
+  ros::Duration getAbortingTime() {return aborting_->getCummulativeTime();}
+  ros::Duration getClearingTime() {return clearing_->getCummulativeTime();}
+  ros::Duration getStoppingTime() {return stopping_->getCummulativeTime();}
+  ros::Duration getResettingTime() {return resetting_->getCummulativeTime();}
+  ros::Duration getSuspendingTime() {return suspending_->getCummulativeTime();}
+  ros::Duration getUnsuspendingTime() {return unsuspending_->getCummulativeTime();}
+  ros::Duration getHoldingTime() {return holding_->getCummulativeTime();}
+  ros::Duration getUnholdingTime() {return unholding_->getCummulativeTime();}
+  ros::Duration getHeldTime() {return held_->getCummulativeTime();}
+  ros::Duration getSuspendedTime() {return suspended_->getCummulativeTime();}
+  ros::Duration getStoppedTime() {return stopped_->getCummulativeTime();}
+  ros::Duration getCompleteTime() {return complete_->getCummulativeTime();}
+  ros::Duration getAbortedTime() {return aborted_->getCummulativeTime();}
+
   virtual ~StateMachine();
 
 
@@ -171,6 +189,10 @@ signals:
 
 };
 
+/**
+ *  ContinuousCycle is used to make the execute function running in a loop
+ *  The execute function cannot complete.
+ */
 class ContinuousCycle : public StateMachine
 {
   Q_OBJECT
@@ -182,6 +204,9 @@ public:
 
 };
 
+/**
+ *  SingleCycle is used to make the execute function running once and passing to completing
+ */
 class SingleCycle : public StateMachine
 {
   Q_OBJECT

--- a/packml_sm/src/state.cpp
+++ b/packml_sm/src/state.cpp
@@ -30,6 +30,7 @@ void PackmlState::onEntry(QEvent *e)
   ROS_DEBUG_STREAM("Entering state: " << name_.toStdString() << "(" << state_ <<")");
   emit stateEntered(static_cast<int>(state_), name_);
   enter_time_ = ros::Time::now();
+  running_ = true;
 }
 
 
@@ -41,6 +42,7 @@ void PackmlState::onExit(QEvent *e)
   cummulative_time_ = cummulative_time_ + (exit_time_ - enter_time_);
   ROS_DEBUG_STREAM("Updating cummulative time, for state: " << name_.toStdString() << "("
                   << state_ << ") to: " << cummulative_time_.toSec());
+  running_ = false;
 }
 
 void ActingState::onEntry(QEvent *e)
@@ -48,6 +50,7 @@ void ActingState::onEntry(QEvent *e)
   PackmlState::onEntry(e);
   ROS_DEBUG_STREAM("Starting thread for state operation");
   function_state_ = QtConcurrent::run(std::bind(&ActingState::operation, this));
+  running_ = true;
 }
 
 void ActingState::onExit(QEvent *e)
@@ -58,6 +61,7 @@ void ActingState::onExit(QEvent *e)
   }
   function_state_.waitForFinished();
   PackmlState::onExit(e);
+  running_ = false;
 }
 
 

--- a/packml_sm/src/state_machine.cpp
+++ b/packml_sm/src/state_machine.cpp
@@ -308,6 +308,24 @@ bool StateMachine::activate()
 bool StateMachine::deactivate()
 {
   ROS_DEBUG_STREAM("Deactivating state machine");
+  abort();
+  unholding_->stopRunning();
+  held_->stopRunning();
+  holding_->stopRunning();
+  idle_->stopRunning();
+  starting_->stopRunning();
+  completing_->stopRunning();
+  complete_->stopRunning();
+  resetting_->stopRunning();
+  unsuspending_->stopRunning();
+  suspended_->stopRunning();
+  suspending_->stopRunning();
+  stopped_->stopRunning();
+  stopping_->stopRunning();
+  clearing_->stopRunning();
+  aborted_->stopRunning();
+  aborting_->stopRunning();
+  execute_->stopRunning();
   sm_internal_.stop();
 }
 


### PR DESCRIPTION
This pull request is done to be able to retrieve the duration statistics of every state.
Then, a server can concatenate every data to make big stats !

I create a running status for the states.