### PR TITLE
Release 0.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,16 @@ env:
   matrix:
     - USE_DEB=true  ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - USE_DEB=true  ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic" PRERELEASE=true
+    - USE_DEB=true  ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="melodic" PRERELEASE=true
 matrix:
   allow_failures:
     - env: USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - env: USE_DEB=true  ROS_DISTRO="kinetic" PRERELEASE=true
+    - env: USE_DEB=true  ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: USE_DEB=true  ROS_DISTRO="melodic" PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script: 

--- a/packml_gui/CHANGELOG.rst
+++ b/packml_gui/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package packml_gui
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Initial release
+* Contributors: AustinDeric, Geoffrey Chiou, Shaun Edwards

--- a/packml_gui/CHANGELOG.rst
+++ b/packml_gui/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package packml_gui
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.0 (2019-07-02)
+------------------
 * Initial release
 * Contributors: AustinDeric, Geoffrey Chiou, Shaun Edwards

--- a/packml_gui/package.xml
+++ b/packml_gui/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>packml_gui</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>GUI for packml control/display</description>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <license>Apache 2.0</license>

--- a/packml_msgs/CHANGELOG.rst
+++ b/packml_msgs/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package packml_msgs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Initial release
+* Contributors: Joshua Curtis, Shaun Edwards

--- a/packml_msgs/CHANGELOG.rst
+++ b/packml_msgs/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package packml_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.0 (2019-07-02)
+------------------
 * Initial release
 * Contributors: Joshua Curtis, Shaun Edwards

--- a/packml_msgs/package.xml
+++ b/packml_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>packml_msgs</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>Packml messages</description>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <license>Apache 2.0</license>

--- a/packml_ros/CHANGELOG.rst
+++ b/packml_ros/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package packml_ros
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Initial release
+* Contributors: AustinDeric, Geoffrey Chiou, Joshua Curtis, Joshua Hatzenbuehler, Shaun Edwards

--- a/packml_ros/CHANGELOG.rst
+++ b/packml_ros/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package packml_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.0 (2019-07-02)
+------------------
 * Initial release
 * Contributors: AustinDeric, Geoffrey Chiou, Joshua Curtis, Joshua Hatzenbuehler, Shaun Edwards

--- a/packml_ros/package.xml
+++ b/packml_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>packml_ros</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>ROS wrapper around packml state machine</description>
 
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>

--- a/packml_sm/CHANGELOG.rst
+++ b/packml_sm/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package packml_sm
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Initial release
+* Contributors: AustinDeric, Geoffrey Chiou, Isaac I.Y. Saito, Joshua Curtis, Joshua Hatzenbuehler, Shaun Edwards

--- a/packml_sm/CHANGELOG.rst
+++ b/packml_sm/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package packml_sm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.0 (2019-07-02)
+------------------
 * Initial release
 * Contributors: AustinDeric, Geoffrey Chiou, Isaac I.Y. Saito, Joshua Curtis, Joshua Hatzenbuehler, Shaun Edwards

--- a/packml_sm/package.xml
+++ b/packml_sm/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>packml_sm</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>Packml state machine</description>
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <license>Apache 2.0</license>

--- a/packml_stacklight/CHANGELOG.rst
+++ b/packml_stacklight/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package packml_stacklight
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Initial release
+* Contributors: Joshua Hatzenbuehler, winchesterag

--- a/packml_stacklight/CHANGELOG.rst
+++ b/packml_stacklight/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package packml_stacklight
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.0 (2019-07-02)
+------------------
 * Initial release
 * Contributors: Joshua Hatzenbuehler, winchesterag

--- a/packml_stacklight/package.xml
+++ b/packml_stacklight/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>packml_stacklight</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>ROS node to bridge packxml state machine and digital output</description>
 
   <maintainer email="joshuahatz@gmail.com">Joshua Hatzenbuehler</maintainer>


### PR DESCRIPTION
# Changes in this PR

- For all packages,
   - Add CHANGELOG.
   - Bump versions in `package.xml`.
- Locally generated tag but haven't pushed it yet. Since I'm unsure if I'm expected to make releases yet (offered at https://github.com/ros-industrial-consortium/packml/issues/46#issuecomment-507386875), I haven't tried pushing it to the remote origin.
- Also, not really related to release, but updated CI config to:
   - Add ROS Melodic.
   - Add ROS pre-release testing (allow to fail. This won't pass unless the package is listed on rosdistro, which is not yet the case for packml. Only useful once it's released).
